### PR TITLE
Fix #78: Weather multi-location support

### DIFF
--- a/app/controllers/weather_controller.rb
+++ b/app/controllers/weather_controller.rb
@@ -2,43 +2,34 @@ class WeatherController < ApplicationController
   before_action :authenticate
 
   def index
-    if params[:lat].present? && params[:lon].present?
-      lat = params[:lat].to_f
-      lon = params[:lon].to_f
-      cookies[:weather_lat] = { value: lat.to_s, expires: 1.year }
-      cookies[:weather_lon] = { value: lon.to_s, expires: 1.year }
-      cookies.delete(:weather_zip)
-      @weather = WeatherService.fetch(lat: lat, lon: lon)
-    elsif cookies[:weather_zip].present?
-      @zip = cookies[:weather_zip]
-      geo = WeatherService.geocode_zip(@zip)
-      if geo
-        @weather = WeatherService.fetch(lat: geo[:lat], lon: geo[:lon])
-        @weather[:location_name] = geo[:name] if @weather
-      end
-    elsif cookies[:weather_lat].present? && cookies[:weather_lon].present?
-      @weather = WeatherService.fetch(lat: cookies[:weather_lat].to_f, lon: cookies[:weather_lon].to_f)
-    end
+    @weather_locations = current_user.weather_locations.order(primary: :desc, created_at: :asc)
+    @primary_location = @weather_locations.find(&:primary?) || @weather_locations.first
 
-    flash.now[:alert] = "Could not fetch weather data. Please try again." if location_provided? && @weather.nil?
+    if @primary_location
+      @weather = WeatherService.fetch(lat: @primary_location.latitude, lon: @primary_location.longitude)
+      if @weather
+        @weather[:location_name] ||= @primary_location.display_name
+      else
+        flash.now[:alert] = "Could not fetch weather data. Please try again."
+      end
+    end
   end
 
   def lookup
     zip = params[:zip].to_s.strip
     geo = WeatherService.geocode_zip(zip)
     if geo
-      cookies[:weather_zip] = { value: zip, expires: 1.year }
-      cookies[:weather_lat] = { value: geo[:lat].to_s, expires: 1.year }
-      cookies[:weather_lon] = { value: geo[:lon].to_s, expires: 1.year }
+      is_first = current_user.weather_locations.none?
+      current_user.weather_locations.create!(
+        latitude: geo[:lat],
+        longitude: geo[:lon],
+        zip: zip,
+        location_name: geo[:name],
+        primary: is_first
+      )
       redirect_to weather_path
     else
       redirect_to weather_path, alert: "Could not find location for zip code \"#{zip}\"."
     end
-  end
-
-  private
-
-  def location_provided?
-    params[:lat].present? || cookies[:weather_zip].present? || cookies[:weather_lat].present?
   end
 end

--- a/app/controllers/weather_locations_controller.rb
+++ b/app/controllers/weather_locations_controller.rb
@@ -1,0 +1,63 @@
+class WeatherLocationsController < ApplicationController
+  before_action :authenticate
+  before_action :set_weather_location, only: [:update, :destroy, :set_primary]
+
+  def create
+    @weather_location = current_user.weather_locations.new(weather_location_params)
+
+    # First location is automatically primary
+    @weather_location.primary = true if current_user.weather_locations.none?
+
+    # Resolve location name from geocoding if we have a zip
+    if @weather_location.zip.present? && @weather_location.location_name.blank?
+      geo = WeatherService.geocode_zip(@weather_location.zip)
+      if geo
+        @weather_location.latitude = geo[:lat]
+        @weather_location.longitude = geo[:lon]
+        @weather_location.location_name = geo[:name]
+      end
+    end
+
+    if @weather_location.save
+      redirect_to weather_path
+    else
+      redirect_to weather_path, alert: "Could not save location."
+    end
+  end
+
+  def update
+    if @weather_location.update(weather_location_params.slice(:name))
+      redirect_to weather_path
+    else
+      redirect_to weather_path, alert: "Could not update location."
+    end
+  end
+
+  def destroy
+    was_primary = @weather_location.primary?
+    @weather_location.destroy
+
+    # If we deleted the primary, promote the next one
+    if was_primary
+      next_location = current_user.weather_locations.first
+      next_location&.update!(primary: true)
+    end
+
+    redirect_to weather_path
+  end
+
+  def set_primary
+    @weather_location.make_primary!
+    redirect_to weather_path
+  end
+
+  private
+
+  def set_weather_location
+    @weather_location = current_user.weather_locations.find(params[:id])
+  end
+
+  def weather_location_params
+    params.require(:weather_location).permit(:name, :latitude, :longitude, :zip, :location_name)
+  end
+end

--- a/app/javascript/controllers/weather_location_controller.js
+++ b/app/javascript/controllers/weather_location_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["detectButton", "status"]
+  static values = { createUrl: String }
 
   detectLocation() {
     if (!navigator.geolocation) {
@@ -17,7 +18,7 @@ export default class extends Controller {
       (position) => {
         const lat = position.coords.latitude.toFixed(4)
         const lon = position.coords.longitude.toFixed(4)
-        window.location.href = `/weather?lat=${lat}&lon=${lon}`
+        this.saveLocation(lat, lon)
       },
       (error) => {
         this.detectButtonTarget.disabled = false
@@ -38,6 +39,31 @@ export default class extends Controller {
       },
       { timeout: 10000, enableHighAccuracy: false }
     )
+  }
+
+  saveLocation(lat, lon) {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+    const form = document.createElement("form")
+    form.method = "post"
+    form.action = this.createUrlValue
+
+    const fields = {
+      "authenticity_token": csrfToken,
+      "weather_location[latitude]": lat,
+      "weather_location[longitude]": lon,
+      "weather_location[location_name]": "My Location"
+    }
+
+    for (const [name, value] of Object.entries(fields)) {
+      const input = document.createElement("input")
+      input.type = "hidden"
+      input.name = name
+      input.value = value
+      form.appendChild(input)
+    }
+
+    document.body.appendChild(form)
+    form.submit()
   }
 
   showStatus(message) {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :projects, foreign_key: :owner_id, dependent: :destroy
   has_many :plants, through: :projects
   has_many :push_subscriptions, dependent: :destroy
+  has_many :weather_locations, dependent: :destroy
 
   after_create :create_default_project
 

--- a/app/models/weather_location.rb
+++ b/app/models/weather_location.rb
@@ -1,0 +1,20 @@
+class WeatherLocation < ApplicationRecord
+  belongs_to :user
+
+  validates :latitude, presence: true
+  validates :longitude, presence: true
+  validates :name, length: { maximum: 100 }
+
+  scope :primary, -> { where(primary: true) }
+
+  def display_name
+    name.presence || location_name.presence || "#{latitude}, #{longitude}"
+  end
+
+  def make_primary!
+    transaction do
+      user.weather_locations.where(primary: true).update_all(primary: false)
+      update!(primary: true)
+    end
+  end
+end

--- a/app/views/weather/index.html.erb
+++ b/app/views/weather/index.html.erb
@@ -2,28 +2,89 @@
 
 <h1>Weather</h1>
 
-<div class="settings-card" data-controller="weather-location">
-  <h2>Location</h2>
+<% if @weather_locations.any? %>
+  <%# Location management view %>
+  <div class="settings-card">
+    <h2>Locations</h2>
 
-  <%= form_with url: weather_lookup_path, method: :post, local: true do |f| %>
-    <div class="field">
-      <%= f.label :zip, "Zip Code" %>
-      <div style="display: flex; gap: 0.5rem; align-items: flex-start;">
-        <%= f.text_field :zip, value: @zip, placeholder: "e.g. 10001", maxlength: 10, style: "flex: 1; width: auto; min-width: 0;" %>
-        <%= f.submit "Look Up", class: "saveButton", style: "width: auto; flex-shrink: 0;" %>
+    <% @weather_locations.each do |location| %>
+      <div class="info-row" style="align-items: center;">
+        <strong>
+          <%= location.display_name %>
+          <% if location.primary? && @weather_locations.size > 1 %>
+            <span style="font-size: 0.8em; opacity: 0.6;">(primary)</span>
+          <% end %>
+        </strong>
+        <span class="value" style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; justify-content: flex-end;">
+          <% unless location.primary? %>
+            <%= button_to "Set Primary", set_primary_weather_location_path(location), method: :patch, class: "buttonLinkSmall" %>
+          <% end %>
+          <%= button_to "Delete", weather_location_path(location), method: :delete, class: "buttonLinkSmall buttonLinkDanger",
+                data: { turbo_confirm: "Remove #{location.display_name}?" } %>
+        </span>
       </div>
-    </div>
-  <% end %>
 
-  <div style="margin-top: 0.75rem;">
-    <button type="button" class="buttonLink" style="width: 100%; text-align: center;"
-            data-action="click->weather-location#detectLocation"
-            data-weather-location-target="detectButton">
-      Use My Location
-    </button>
-    <p data-weather-location-target="status" style="font-size: 0.85em; color: #888; margin: 0.25rem 0 0 0; display: none;"></p>
+      <%# Inline rename form %>
+      <div style="margin: 0.25rem 0 0.75rem 0;">
+        <%= form_with model: location, url: weather_location_path(location), method: :patch, local: true do |f| %>
+          <div style="display: flex; gap: 0.5rem; align-items: flex-start;">
+            <%= f.text_field :name, value: location.name, placeholder: "Name this location", style: "flex: 1; width: auto; min-width: 0; font-size: 0.9em;" %>
+            <%= f.submit "Save", class: "saveButton", style: "width: auto; flex-shrink: 0; font-size: 0.9em;" %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%# Add another location %>
+    <details style="margin-top: 0.75rem;">
+      <summary class="buttonLink" style="text-align: center; cursor: pointer;">Add Location</summary>
+      <div style="margin-top: 0.75rem;" data-controller="weather-location" data-weather-location-create-url-value="<%= weather_locations_path %>">
+        <%= form_with url: weather_lookup_path, method: :post, local: true do |f| %>
+          <div class="field">
+            <%= f.label :zip, "Zip Code" %>
+            <div style="display: flex; gap: 0.5rem; align-items: flex-start;">
+              <%= f.text_field :zip, placeholder: "e.g. 10001", maxlength: 10, style: "flex: 1; width: auto; min-width: 0;" %>
+              <%= f.submit "Look Up", class: "saveButton", style: "width: auto; flex-shrink: 0;" %>
+            </div>
+          </div>
+        <% end %>
+
+        <div style="margin-top: 0.75rem;">
+          <button type="button" class="buttonLink" style="width: 100%; text-align: center;"
+                  data-action="click->weather-location#detectLocation"
+                  data-weather-location-target="detectButton">
+            Use My Location
+          </button>
+          <p data-weather-location-target="status" style="font-size: 0.85em; color: #888; margin: 0.25rem 0 0 0; display: none;"></p>
+        </div>
+      </div>
+    </details>
   </div>
-</div>
+<% else %>
+  <%# No locations — show setup form %>
+  <div class="settings-card" data-controller="weather-location" data-weather-location-create-url-value="<%= weather_locations_path %>">
+    <h2>Location</h2>
+
+    <%= form_with url: weather_lookup_path, method: :post, local: true do |f| %>
+      <div class="field">
+        <%= f.label :zip, "Zip Code" %>
+        <div style="display: flex; gap: 0.5rem; align-items: flex-start;">
+          <%= f.text_field :zip, placeholder: "e.g. 10001", maxlength: 10, style: "flex: 1; width: auto; min-width: 0;" %>
+          <%= f.submit "Look Up", class: "saveButton", style: "width: auto; flex-shrink: 0;" %>
+        </div>
+      </div>
+    <% end %>
+
+    <div style="margin-top: 0.75rem;">
+      <button type="button" class="buttonLink" style="width: 100%; text-align: center;"
+              data-action="click->weather-location#detectLocation"
+              data-weather-location-target="detectButton">
+        Use My Location
+      </button>
+      <p data-weather-location-target="status" style="font-size: 0.85em; color: #888; margin: 0.25rem 0 0 0; display: none;"></p>
+    </div>
+  </div>
+<% end %>
 
 <% if @weather %>
   <div class="info-card">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,11 @@ Rails.application.routes.draw do
 
   get 'weather', to: 'weather#index'
   post 'weather/lookup', to: 'weather#lookup', as: 'weather_lookup'
+  resources :weather_locations, only: [:create, :update, :destroy] do
+    member do
+      patch :set_primary
+    end
+  end
 
   get 'settings', to: 'settings#index'
   patch 'settings', to: 'settings#update'

--- a/db/migrate/20260321100001_create_weather_locations.rb
+++ b/db/migrate/20260321100001_create_weather_locations.rb
@@ -1,0 +1,17 @@
+class CreateWeatherLocations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :weather_locations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name
+      t.decimal :latitude, precision: 9, scale: 4, null: false
+      t.decimal :longitude, precision: 9, scale: 4, null: false
+      t.string :zip
+      t.string :location_name
+      t.boolean :primary, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index :weather_locations, [:user_id, :primary]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_23_100002) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_21_100001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -277,6 +277,20 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_23_100002) do
     t.index ["recipe_id"], name: "index_waterings_on_recipe_id"
   end
 
+  create_table "weather_locations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name"
+    t.decimal "latitude", precision: 9, scale: 4, null: false
+    t.decimal "longitude", precision: 9, scale: 4, null: false
+    t.string "zip"
+    t.string "location_name"
+    t.boolean "primary", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "primary"], name: "index_weather_locations_on_user_id_and_primary"
+    t.index ["user_id"], name: "index_weather_locations_on_user_id"
+  end
+
   create_table "zones", force: :cascade do |t|
     t.string "name"
     t.integer "project_id"
@@ -301,4 +315,5 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_23_100002) do
   add_foreign_key "water_tests", "tanks"
   add_foreign_key "waterings", "recipe_batches"
   add_foreign_key "waterings", "recipes"
+  add_foreign_key "weather_locations", "users"
 end

--- a/test/controllers/weather_controller_test.rb
+++ b/test/controllers/weather_controller_test.rb
@@ -22,4 +22,17 @@ class WeatherControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to weather_path
     assert_match "Could not find location", flash[:alert]
   end
+
+  test "should show location form when no locations saved" do
+    get weather_path
+    assert_response :success
+    assert_select ".settings-card h2", "Location"
+  end
+
+  test "should show location management when locations exist" do
+    @user.weather_locations.create!(latitude: 40.7128, longitude: -74.006, location_name: "New York", primary: true)
+    get weather_path
+    assert_response :success
+    assert_select ".settings-card h2", "Locations"
+  end
 end

--- a/test/controllers/weather_locations_controller_test.rb
+++ b/test/controllers/weather_locations_controller_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class WeatherLocationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    sign_in @user
+    @location = @user.weather_locations.create!(
+      latitude: 40.7128,
+      longitude: -74.006,
+      location_name: "New York",
+      name: "Home",
+      primary: true
+    )
+  end
+
+  test "should create weather location" do
+    assert_difference("WeatherLocation.count") do
+      post weather_locations_path, params: {
+        weather_location: { latitude: 34.0522, longitude: -118.2437, location_name: "Los Angeles" }
+      }
+    end
+    assert_redirected_to weather_path
+  end
+
+  test "should update weather location name" do
+    patch weather_location_path(@location), params: {
+      weather_location: { name: "NYC" }
+    }
+    assert_redirected_to weather_path
+    @location.reload
+    assert_equal "NYC", @location.name
+  end
+
+  test "should destroy weather location" do
+    assert_difference("WeatherLocation.count", -1) do
+      delete weather_location_path(@location)
+    end
+    assert_redirected_to weather_path
+  end
+
+  test "should set primary" do
+    second = @user.weather_locations.create!(latitude: 34.0522, longitude: -118.2437, location_name: "LA")
+    patch set_primary_weather_location_path(second)
+    assert_redirected_to weather_path
+    second.reload
+    @location.reload
+    assert second.primary?
+    assert_not @location.primary?
+  end
+
+  test "should not access other users locations" do
+    other_user = users(:two)
+    other_location = other_user.weather_locations.create!(latitude: 51.5, longitude: -0.1, location_name: "London", primary: true)
+    delete weather_location_path(other_location)
+    assert_redirected_to plants_path
+  end
+
+  test "destroying primary promotes next location" do
+    second = @user.weather_locations.create!(latitude: 34.0522, longitude: -118.2437, location_name: "LA")
+    delete weather_location_path(@location)
+    second.reload
+    assert second.primary?
+  end
+end

--- a/test/fixtures/weather_locations.yml
+++ b/test/fixtures/weather_locations.yml
@@ -1,0 +1,1 @@
+# empty — weather locations created in test setup


### PR DESCRIPTION
## Summary
- Add `WeatherLocation` model with DB persistence (replaces cookie-based location storage)
- Add `WeatherLocationsController` with create, update (rename), destroy, and set_primary actions
- Weather view shows location management UI when locations exist, setup form when empty
- Support multiple saved locations with primary selection
- "Use My Location" geolocation now saves to DB via form POST instead of URL params
- Cross-user isolation enforced via `current_user.weather_locations.find`

Closes #78

## Test plan
- [ ] Visit Weather with no saved locations — see zip code form + "Use My Location"
- [ ] Add a location via zip code — redirects back, shows weather + location management
- [ ] Add a second location — both appear, can set primary
- [ ] Rename a location via inline form
- [ ] Delete a location — if primary, next one is promoted
- [ ] "Use My Location" saves coordinates to DB
- [ ] Run `bin/rails test test/controllers/weather_locations_controller_test.rb` (6 tests)
- [ ] Run `bin/rails test test/controllers/weather_controller_test.rb` (5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)