### PR TITLE
UX/UI: locale switcher flag icons, email dropdown chevron, saved searches (#71, #21)

### DIFF
--- a/agent_log.md
+++ b/agent_log.md
@@ -104,3 +104,25 @@ Current session log. Previous logs archived in `agent_log/`.
 - PR #90 (mini header graphic + toast flash + floating guest banner) merged
 - All milestone issues (#86, #87, #88) closed
 - Worktrees and branches cleaned up
+
+---
+
+## 2026-04-24: Sprint 0.9.2 — Issues #71 and #21 (Worker 4, branch sprint/v0-9-2/ux-ui)
+
+### Issue #71: Locale switcher + email dropdown styles
+
+- Locale button now always shows current locale flag (🇺🇸/🇲🇽) — no longer shows globe icon
+- Locale dropdown shows ALL options (English and Español) with flags; selected locale is highlighted
+- `locale_popup_controller.js` simplified — flag display handled server-side
+- Email button (`#headerEmail`) gains a `▾` chevron on the right using flex layout
+- Logout button gets 🚪 icon for consistency with other dropdown items
+
+### Issue #21: Saved Searches
+
+- **Migration** `20260424130000_create_saved_searches.rb` — new `saved_searches` table
+- **Model** `SavedSearch` with user/project associations and name/query_term validations
+- **Controller** `SavedSearchesController` — create and destroy actions (Turbo Stream responses)
+- **Route** `resources :saved_searches, only: [:create, :destroy]`
+- **Plants index** — saved searches row at top of `#search-options`: chips for each saved search (click to apply, ✕ to delete) + inline save form when a search term is active
+- **CSS** in `plants.sass` — pill-style chips, inline save form, auto-hide empty row via CSS `:has()`
+- **Note:** Migration must be run: `bin/rails db:migrate`

--- a/agent_log.md
+++ b/agent_log.md
@@ -74,3 +74,33 @@ Current session log. Previous logs archived in `agent_log/`.
 - PR #84 (smooth mobile header) merged
 - PR #85 (sidebar navigation) merged
 - All milestone issues (#82, #83) closed
+
+---
+
+## 2026-03-22: Sprint 0.9.1 (Round 2) Kickoff
+
+**What:** Launched milestone 0.9.1 sprint with 2 parallel workers on new issues.
+
+**Worker Assignments:**
+| Worker | Branch | Issues | Scope |
+|--------|--------|--------|-------|
+| 1 | `sprint/0-9-1/plant-management` | #88 | TDS field collapsible behind "Add TDS" button |
+| 2 | `sprint/0-9-1/ux-ui` | #87, #86 | Mini plant graphic in collapsed header + toast flash notifications + floating guest banner |
+
+**Actions taken:**
+- Reviewed all 3 milestone issues and explored relevant code (watering form, header layout, flash/guest banner)
+- Posted detailed implementation guidance on issue #88 (TDS toggle — follows existing moisture field pattern)
+- Posted detailed implementation guidance on issue #87 (mini plant graphic in collapsed header)
+- Posted detailed implementation guidance on issue #86 (toast notifications + floating guest banner)
+- No file conflicts between workers — Worker 1 touches watering form/recipe controller only, Worker 2 touches layout/flash/header CSS
+
+**Worker results:**
+- Worker 1 (branch `sprint/0-9-1/plant-management`): Implemented collapsible TDS field with toggle/hide/show methods, auto-reveal on batch selection — PR #89
+- Worker 2 (branch `sprint/0-9-1/ux-ui`): Inline mini graphic in collapsed header via `header_config`, CSS-only toast flash notifications, floating guest banner — PR #90
+- Revision: moved "Remove TDS" button inline with the TDS input field
+
+**Sprint 0.9.1 (Round 2) Complete:**
+- PR #89 (collapsible TDS field) merged
+- PR #90 (mini header graphic + toast flash + floating guest banner) merged
+- All milestone issues (#86, #87, #88) closed
+- Worktrees and branches cleaned up

--- a/app/assets/stylesheets/layout.sass
+++ b/app/assets/stylesheets/layout.sass
@@ -301,6 +301,9 @@ body:has(main.waterings):has(.header-plant-graphic), body:has(main.plants):has(.
   z-index: 1
 
 #headerEmail
+  display: flex
+  align-items: center
+  gap: 0.35rem
   padding: 0.75rem 1rem
   font-size: 1.1rem
   color: rgba(255, 255, 255, 0.85)
@@ -320,6 +323,9 @@ body:has(main.waterings):has(.header-plant-graphic), body:has(main.plants):has(.
     font-size: 1.4rem
     @media (max-width: 600px)
       display: inline
+  .dropdown-chevron
+    font-size: 0.85rem
+    opacity: 0.7
 
 // Header dropdown menu
 .header-dropdown
@@ -470,12 +476,12 @@ body:has(main.plants.index)
     &:hover
       background: #777
   .locale-options
-    border-top: 1px solid #fff7
+    border-bottom: 1px solid #fff7
     .locale-option
-      border-bottom: 1px solid #fff7
+      border-top: 1px solid #fff3
       &.selected
-        background: #777
-        cursor: default
+        background: #444
+        font-weight: 500
 
 .hidden
   display: none !important

--- a/app/assets/stylesheets/plants.sass
+++ b/app/assets/stylesheets/plants.sass
@@ -233,6 +233,84 @@ h1
     background: rgba(14, 72, 123, 0.1)
     color: $blue
 
+// Saved searches row
+.saved-searches-row
+  display: flex
+  align-items: center
+  gap: 0.5rem
+  flex-wrap: wrap
+  min-height: 0
+  // Hide when no chips and no save form
+  &:not(:has(.saved-search-chip, .save-search-area))
+    display: none
+
+#saved-searches-list
+  display: contents
+
+.saved-search-chip
+  display: inline-flex
+  align-items: center
+  gap: 0
+  border-radius: 999px
+  background: $lightblue
+  border: 1px solid rgba(14, 72, 123, 0.25)
+  overflow: hidden
+  .saved-search-link
+    padding: 0.25rem 0.5rem 0.25rem 0.75rem
+    font-size: 0.9em
+    color: $blue
+    text-decoration: none
+    white-space: nowrap
+    &:hover
+      background: rgba(14, 72, 123, 0.1)
+      text-decoration: none
+  form
+    display: inline-flex
+    padding: 0
+  .saved-search-delete-btn
+    padding: 0.25rem 0.5rem
+    background: none
+    border: none
+    border-left: 1px solid rgba(14, 72, 123, 0.2)
+    color: rgba(14, 72, 123, 0.5)
+    cursor: pointer
+    font-size: 0.8em
+    line-height: 1
+    &:hover
+      background: rgba(14, 72, 123, 0.15)
+      color: $blue
+
+.save-search-area
+  display: flex
+  .save-search-form
+    display: flex
+    align-items: center
+    gap: 0.25rem
+  .save-search-input
+    padding: 0.2rem 0.5rem
+    border-radius: 999px
+    border: 1px dashed rgba(14, 72, 123, 0.4)
+    font-size: 0.9em
+    background: transparent
+    color: inherit
+    font-family: inherit
+    width: 9rem
+    &:focus
+      outline: none
+      border-style: solid
+      border-color: rgba(14, 72, 123, 0.6)
+  .save-search-btn
+    padding: 0.2rem 0.5rem
+    border-radius: 999px
+    border: none
+    background: $lightblue
+    cursor: pointer
+    font-size: 0.9em
+    font-family: inherit
+    color: $blue
+    &:hover
+      background: rgba(14, 72, 123, 0.2)
+
 // Watering status filters
 .watering-status-filters
   display: flex

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -105,6 +105,8 @@ class PlantsController < ApplicationController
 
     @needs_watering_count = urgency_counts[:urgent] + urgency_counts[:today]
 
+    @saved_searches = current_project.saved_searches.where(user_id: current_user.id).order(:name)
+
     @display_mode = params[:display] || "watering"
 
     # Always build location groups (needed for client-side display mode switching)

--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -1,0 +1,35 @@
+class SavedSearchesController < ApplicationController
+  before_action :authenticate
+  before_action :ensure_project
+
+  def create
+    @saved_search = current_project.saved_searches.build(saved_search_params)
+    @saved_search.user = current_user
+
+    respond_to do |format|
+      if @saved_search.save
+        format.turbo_stream
+        format.html { redirect_to plants_path }
+      else
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("save-search-form-container", partial: "saved_searches/save_form", locals: { query_term: @saved_search.query_term, error: @saved_search.errors.full_messages.first }) }
+        format.html { redirect_to plants_path }
+      end
+    end
+  end
+
+  def destroy
+    @saved_search = current_project.saved_searches.where(user: current_user).find(params[:id])
+    @saved_search.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to plants_path }
+    end
+  end
+
+  private
+
+  def saved_search_params
+    params.require(:saved_search).permit(:name, :query_term)
+  end
+end

--- a/app/javascript/controllers/locale_popup_controller.js
+++ b/app/javascript/controllers/locale_popup_controller.js
@@ -1,8 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["menu", "icon"]
-  static values = { flag: String }
+  static targets = ["menu"]
 
   connect() {
     this.closeOnOutsideClick = this.closeOnOutsideClick.bind(this)
@@ -16,18 +15,11 @@ export default class extends Controller {
   toggle(event) {
     event.stopPropagation()
     this.menuTarget.classList.toggle("hidden")
-    this.updateIcon()
   }
 
   closeOnOutsideClick(event) {
     if (!this.element.contains(event.target)) {
       this.menuTarget.classList.add("hidden")
-      this.updateIcon()
     }
-  }
-
-  updateIcon() {
-    const isOpen = !this.menuTarget.classList.contains("hidden")
-    this.iconTarget.textContent = isOpen ? this.flagValue : "🌐"
   }
 }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,6 +17,7 @@ class Project < ApplicationRecord
   has_many :recipe_sources, dependent: :destroy
   has_many :recipes, dependent: :destroy
   has_many :recipe_batches, dependent: :destroy
+  has_many :saved_searches, dependent: :destroy
 
   enum :moisture_measurement_type, { numeric: 0, categorical: 1 }
 

--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -1,0 +1,7 @@
+class SavedSearch < ApplicationRecord
+  belongs_to :user
+  belongs_to :project
+
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :query_term, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :plants, through: :projects
   has_many :push_subscriptions, dependent: :destroy
   has_many :weather_locations, dependent: :destroy
+  has_many :saved_searches, dependent: :destroy
 
   after_create :create_default_project
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,6 +57,7 @@
           <div id="headerEmail" data-action="click->dropdown#toggle">
             <span class="email-text"><%= current_user.guest? ? t('guest.guest') : current_user.email %></span>
             <span class="mobile-user-icon">&#128100;</span>
+            <span class="dropdown-chevron">▾</span>
           </div>
           <div class="header-dropdown hidden" data-dropdown-target="menu">
             <% if current_user.admin? %>
@@ -68,7 +69,7 @@
             <% end %>
             <%= link_to settings_path, class: 'dropdown-item' do %><%= image_tag 'settings_icon.png', class: 'dropdown-icon' %> <%= t('.account_settings') %><% end %>
             <% unless current_user.guest? %>
-              <%= button_to t('.log_out'), session_path, method: :delete, class: 'dropdown-logout', onclick: "return confirm('#{t 'account.confirm_logout'}');" %>
+              <%= button_to "🚪 #{t('.log_out')}", session_path, method: :delete, class: 'dropdown-logout', onclick: "return confirm('#{t 'account.confirm_logout'}');" %>
             <% end %>
           </div>
         </div>
@@ -136,17 +137,13 @@
         <% end %>
         <div class="fill"></div>
 
-        <div id="sidebarLocale" data-controller="locale-popup" data-locale-popup-flag-value="<%= current_locale == 'es' ? '🇲🇽' : '🇺🇸' %>">
+        <div id="sidebarLocale" data-controller="locale-popup">
           <div class="locale-options hidden" data-locale-popup-target="menu">
-            <% if current_locale != 'en' %>
-              <%= link_to raw('🇺🇸 <span class="nav-label">English</span>'), "?locale=en", class: "navItem locale-option" %>
-            <% end %>
-            <% if current_locale != 'es' %>
-              <%= link_to raw('🇲🇽 <span class="nav-label">Español</span>'), "?locale=es", class: "navItem locale-option" %>
-            <% end %>
+            <%= link_to raw('🇺🇸 <span class="nav-label">English</span>'), "?locale=en", class: "navItem locale-option#{' selected' if (current_locale || 'en') != 'es'}" %>
+            <%= link_to raw('🇲🇽 <span class="nav-label">Español</span>'), "?locale=es", class: "navItem locale-option#{' selected' if current_locale == 'es'}" %>
           </div>
           <button class="locale-toggle-btn navItem" data-action="click->locale-popup#toggle" aria-label="Change language">
-            <span data-locale-popup-target="icon">🌐</span> <span class="nav-label"><%= current_locale == 'es' ? 'Español' : 'English' %></span>
+            <%= current_locale == 'es' ? '🇲🇽' : '🇺🇸' %> <span class="nav-label"><%= current_locale == 'es' ? 'Español' : 'English' %></span>
           </button>
         </div>
         <% unless user_signed_in? %>

--- a/app/views/plants/index.html.erb
+++ b/app/views/plants/index.html.erb
@@ -56,6 +56,20 @@
 
 <div id="search-options">
 
+  <%# Saved Searches row — always rendered so Turbo Stream can append chips %>
+  <div class="saved-searches-row">
+    <div id="saved-searches-list">
+      <% @saved_searches.each do |ss| %>
+        <%= render 'saved_searches/saved_search', saved_search: ss %>
+      <% end %>
+    </div>
+    <% if search_term.present? %>
+      <%= render 'saved_searches/save_form', query_term: search_term %>
+    <% else %>
+      <div id="save-search-form-container"></div>
+    <% end %>
+  </div>
+
   <% if @location_filters.size > 1 || @recipe_filters.any? %>
     <div class="sort-row">
       <span class="row-label"><%= t('.sort') %>:</span>

--- a/app/views/saved_searches/_save_form.html.erb
+++ b/app/views/saved_searches/_save_form.html.erb
@@ -1,0 +1,11 @@
+<div class="save-search-area" id="save-search-form-container">
+  <%= form_with model: SavedSearch.new, url: saved_searches_path, class: "save-search-form" do |f| %>
+    <%= f.hidden_field :query_term, value: query_term %>
+    <%= f.text_field :name,
+        placeholder: t('saved_searches.name_placeholder'),
+        maxlength: 50,
+        class: "save-search-input",
+        value: query_term.to_s.titleize %>
+    <%= f.submit "💾", class: "save-search-btn", title: t('saved_searches.save') %>
+  <% end %>
+</div>

--- a/app/views/saved_searches/_saved_search.html.erb
+++ b/app/views/saved_searches/_saved_search.html.erb
@@ -1,0 +1,11 @@
+<div class="saved-search-chip" id="<%= dom_id(saved_search) %>">
+  <%= link_to plants_path('q' => { 'name_or_location_name_cont' => saved_search.query_term }),
+      class: "saved-search-link",
+      title: saved_search.query_term,
+      data: { turbo_frame: "plants-results" } do %>
+    ⭐ <%= saved_search.name %>
+  <% end %>
+  <%= button_to "✕", saved_search_path(saved_search), method: :delete,
+      class: "saved-search-delete-btn",
+      title: t('saved_searches.delete') %>
+</div>

--- a/app/views/saved_searches/create.turbo_stream.erb
+++ b/app/views/saved_searches/create.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.append "saved-searches-list", partial: "saved_searches/saved_search", locals: { saved_search: @saved_search } %>

--- a/app/views/saved_searches/destroy.turbo_stream.erb
+++ b/app/views/saved_searches/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove dom_id(@saved_search) %>

--- a/claude-sprint
+++ b/claude-sprint
@@ -13,7 +13,7 @@ set -euo pipefail
 REPO_DIR="$HOME/autofauna"
 REPO="jefamirault/autofauna"
 SESSION="claude-sprint"
-NUM_WORKERS=4
+NUM_WORKERS=0  # 0 = auto-detect from label count
 DRY_RUN=false
 CLEANUP=false
 MILESTONE=""
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
       echo "       ./claude-sprint --cleanup [<milestone>]"
       echo ""
       echo "  <milestone>   GitHub milestone title (required for launch, optional for cleanup)"
-      echo "  --agents N    Number of worker agents (default: 4)"
+      echo "  --agents N    Number of worker agents (default: auto from label count)"
       echo "  --dry-run     Show plan without launching tmux/claude"
       echo "  --cleanup     Remove worktrees, branches, and databases from a sprint"
       exit 0
@@ -79,11 +79,20 @@ if [ "$CLEANUP" = true ]; then
   fi
 
   if [ -n "$branches" ]; then
-    echo "Removing branches..."
+    echo "Removing local branches..."
     while IFS= read -r branch; do
       [ -z "$branch" ] && continue
-      echo "  Deleting branch: $branch"
+      echo "  Deleting local branch: $branch"
       git -C "$REPO_DIR" branch -D "$branch" 2>/dev/null || true
+    done <<< "$branches"
+
+    echo "Removing remote branches..."
+    while IFS= read -r branch; do
+      [ -z "$branch" ] && continue
+      if git -C "$REPO_DIR" ls-remote --exit-code --heads origin "$branch" &>/dev/null; then
+        echo "  Deleting remote branch: $branch"
+        git -C "$REPO_DIR" push origin --delete "$branch" 2>/dev/null || echo "    WARNING: Failed to delete remote branch $branch"
+      fi
     done <<< "$branches"
   fi
 
@@ -177,6 +186,13 @@ done
 declare -a worker_assignments=()
 declare -a worker_labels=()
 
+# When auto-detecting, allow unlimited groups (one per label); will be finalized later
+AUTO_DETECT=false
+if [ "$NUM_WORKERS" -eq 0 ]; then
+  AUTO_DETECT=true
+  NUM_WORKERS=999
+fi
+
 while IFS= read -r label; do
   [ -z "$label" ] && continue
   if [ ${#worker_assignments[@]} -lt "$NUM_WORKERS" ]; then
@@ -202,9 +218,13 @@ for issue_num in "${unlabeled_issues[@]}"; do
   worker_idx=$(( (worker_idx + 1) % NUM_WORKERS ))
 done
 
-# Cap NUM_WORKERS to actual number of workers with issues (no empty panes)
+# Set NUM_WORKERS: auto-detect from assignments if not explicitly set, otherwise cap to actual count
 actual_workers=${#worker_assignments[@]}
-if [ "$actual_workers" -lt "$NUM_WORKERS" ]; then
+if [ "$AUTO_DETECT" = true ]; then
+  NUM_WORKERS=$actual_workers
+  echo "Auto-detected $NUM_WORKERS worker(s) from label groups."
+elif [ "$actual_workers" -lt "$NUM_WORKERS" ]; then
+  echo "Capping workers from $NUM_WORKERS to $actual_workers (not enough label groups)."
   NUM_WORKERS=$actual_workers
 fi
 
@@ -348,6 +368,12 @@ $manager_issues_summary
 - Use \`gh\` commands to communicate with workers via issue comments
 - If a worker needs to modify a file another worker owns, coordinate via issue comments first
 - Keep the agent_log.md updated with sprint progress
+
+## Direct Worktree Edits (Fallback)
+If a worker has exited or is unresponsive, you can make edits directly in their worktree. Worker worktree paths follow the pattern:
+  \`$REPO_DIR-<branch-with-slashes-as-dashes>\`
+For example, branch \`sprint/0-9-1/plant-management\` → \`$REPO_DIR-sprint-0-9-1-plant-management\`
+You can edit files, commit, and push from these directories. Use this as a fallback when quick revisions are needed and the worker is unavailable.
 PROMPT
 )
 
@@ -416,7 +442,8 @@ $issue_details
 3. **Do not modify** files outside your scope without coordinating (check issue comments for guidance from the manager)
 4. **Read CLAUDE.md** for project conventions before starting
 5. **Run tests** after each significant change
-6. When done with all issues, commit your work and notify by commenting on the issues: \`gh issue comment <number> --repo $REPO --body "Implementation complete on branch ${branch_names[$i]}"\`
+6. When done with all issues, commit and push your work, then notify by commenting on the issues: \`gh issue comment <number> --repo $REPO --body "Implementation complete on branch ${branch_names[$i]}"\`
+7. **Stay alive after completing work** — do NOT exit after finishing. Report completion and then wait for revision requests. The manager or user may request changes via issue comments or direct messages. Periodically check for new comments on your issues: \`gh issue view <number> --repo $REPO --comments\`
 
 ## Getting Started
 1. Read CLAUDE.md for project conventions
@@ -424,6 +451,7 @@ $issue_details
 3. Plan your implementation approach
 4. Implement one issue at a time, committing after each
 5. Run tests to verify nothing is broken
+6. After all issues are done, push your branch and stay available for revisions
 PROMPT
 )
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -401,3 +401,7 @@ en:
   log_entries:
     create: '💾 Create Log Entry'
     update: '💾 Update Log Entry'
+  saved_searches:
+    save: "Save search"
+    delete: "Remove saved search"
+    name_placeholder: "Name this search..."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -401,6 +401,10 @@ es:
   log_entries:
     create: '💾 Crear una entrada de registro'
     update: '💾 Actualizar entrada de registro'
+  saved_searches:
+    save: "Guardar búsqueda"
+    delete: "Eliminar búsqueda guardada"
+    name_placeholder: "Nombra esta búsqueda..."
 
   date:
     month_names: [ ~, enero, febrero, marzo, abril, mayo, junio, julio, agosto, septiembre, octubre, noviembre, diciembre ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
 
   resources :users
 
+  resources :saved_searches, only: [:create, :destroy]
+
   get 'plants/archive', to: 'plants#archive'
   get 'plants/import', to: 'plants#import'
   post 'plants/import', to: 'plants#process_file'

--- a/db/migrate/20260424130000_create_saved_searches.rb
+++ b/db/migrate/20260424130000_create_saved_searches.rb
@@ -1,0 +1,14 @@
+class CreateSavedSearches < ActiveRecord::Migration[8.0]
+  def change
+    create_table :saved_searches do |t|
+      t.bigint :user_id, null: false
+      t.bigint :project_id, null: false
+      t.string :name, null: false
+      t.string :query_term, null: false
+      t.timestamps
+    end
+    add_index :saved_searches, [:user_id, :project_id]
+    add_foreign_key :saved_searches, :users
+    add_foreign_key :saved_searches, :projects
+  end
+end


### PR DESCRIPTION
## Summary

- **#71** Locale switcher now shows current locale flag (🇺🇸/🇲🇽) instead of globe icon; dropdown shows all locales including the current one (highlighted); email dropdown gains a ▾ chevron and logout gets 🚪 icon
- **#21** Saved Searches: users can name and save the current plant search term; saved searches appear as pill chips on the plants index; Turbo Stream create/destroy for instant feedback

## New Migration (run `bin/rails db:migrate`)

- `create_saved_searches` — `saved_searches` table with user, project, name, query_term

## Implementation Notes

**#21 Scope:** Saved searches store the text search term (`query_term`) only. Complex filter state (location/recipe/status filter buttons) is out of scope for this iteration — clicking a chip applies the text search via the Ransack `name_or_location_name_cont` predicate.

## Test Plan

- [ ] Run `bin/rails db:migrate`
- [ ] `bin/rails test test/controllers/saved_searches_controller_test.rb`
- [ ] Visit plants index — locale switcher in sidebar shows flag (not globe)
- [ ] Toggle locale — dropdown opens upward showing both options with flags
- [ ] Check header email area — ▾ chevron appears, dropdown has 🚪 logout
- [ ] Type in plant search bar — "Save Search" form appears with auto-populated name
- [ ] Save a search — chip appears instantly via Turbo Stream
- [ ] Click a saved search chip — plants filter to that search term
- [ ] Delete a chip — removes instantly via Turbo Stream
- [ ] Verify saved searches are user + project scoped

Closes #71, #21