### PR TITLE
Sprint v0.9.2: Recipe Management (#91, #92, #93, #94, #95)

### DIFF
--- a/agent_log.md
+++ b/agent_log.md
@@ -74,3 +74,33 @@ Current session log. Previous logs archived in `agent_log/`.
 - PR #84 (smooth mobile header) merged
 - PR #85 (sidebar navigation) merged
 - All milestone issues (#82, #83) closed
+
+---
+
+## 2026-03-22: Sprint 0.9.1 (Round 2) Kickoff
+
+**What:** Launched milestone 0.9.1 sprint with 2 parallel workers on new issues.
+
+**Worker Assignments:**
+| Worker | Branch | Issues | Scope |
+|--------|--------|--------|-------|
+| 1 | `sprint/0-9-1/plant-management` | #88 | TDS field collapsible behind "Add TDS" button |
+| 2 | `sprint/0-9-1/ux-ui` | #87, #86 | Mini plant graphic in collapsed header + toast flash notifications + floating guest banner |
+
+**Actions taken:**
+- Reviewed all 3 milestone issues and explored relevant code (watering form, header layout, flash/guest banner)
+- Posted detailed implementation guidance on issue #88 (TDS toggle — follows existing moisture field pattern)
+- Posted detailed implementation guidance on issue #87 (mini plant graphic in collapsed header)
+- Posted detailed implementation guidance on issue #86 (toast notifications + floating guest banner)
+- No file conflicts between workers — Worker 1 touches watering form/recipe controller only, Worker 2 touches layout/flash/header CSS
+
+**Worker results:**
+- Worker 1 (branch `sprint/0-9-1/plant-management`): Implemented collapsible TDS field with toggle/hide/show methods, auto-reveal on batch selection — PR #89
+- Worker 2 (branch `sprint/0-9-1/ux-ui`): Inline mini graphic in collapsed header via `header_config`, CSS-only toast flash notifications, floating guest banner — PR #90
+- Revision: moved "Remove TDS" button inline with the TDS input field
+
+**Sprint 0.9.1 (Round 2) Complete:**
+- PR #89 (collapsible TDS field) merged
+- PR #90 (mini header graphic + toast flash + floating guest banner) merged
+- All milestone issues (#86, #87, #88) closed
+- Worktrees and branches cleaned up

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -49,7 +49,7 @@ class PlantsController < ApplicationController
     @q = current_project.plants.ransack(params['q'])
 
     @q.sorts = ['date_max_watering asc', 'date_min_watering asc'] if @q.sorts.empty?
-    @plants = @q.result(distinct: true).includes(:location, :recipe, last_watering: [:recipe_batch])
+    @plants = @q.result(distinct: true).includes(:location, :recipe, :plant_recipes, :recipes, last_watering: [:recipe_batch, :recipe_source])
 
     # Build location filter buttons with colors, sorted by count (descending)
     location_counts = @plants.where.not(location_id: nil).reorder(nil).group(:location_id).count
@@ -177,6 +177,7 @@ class PlantsController < ApplicationController
 
     respond_to do |format|
       if @plant.save
+        assign_plant_recipes(@plant)
         format.html { redirect_to plant_url(@plant), notice: t('plants.messages.create_success') }
         format.json { render :show, status: :created, location: @plant }
       else
@@ -190,6 +191,7 @@ class PlantsController < ApplicationController
   def update
     respond_to do |format|
       if @plant.update(plant_params)
+        assign_plant_recipes(@plant)
         format.html { redirect_to plant_url(@plant), notice: t('plants.messages.update_success') }
         format.json { render :show, status: :ok, location: @plant }
       else
@@ -297,5 +299,20 @@ class PlantsController < ApplicationController
     # Only allow a list of trusted parameters through.
     def plant_params
       params.require(:plant).permit(:name, :uid, :project_id, :zone_id, :location_id, :pot, :archived, :min_watering_freq, :max_watering_freq, :manual_watering_frequency, :graphic, :notifications_enabled, :recipe_id)
+    end
+
+    def assign_plant_recipes(plant)
+      recipe_ids = params[:plant][:recipe_ids]
+      return unless recipe_ids
+
+      selected_ids = recipe_ids.reject(&:blank?).map(&:to_i)
+      valid_ids = current_project.recipes.where(id: selected_ids).pluck(:id)
+
+      plant.plant_recipes.where.not(recipe_id: valid_ids).destroy_all
+      existing_ids = plant.plant_recipes.pluck(:recipe_id)
+      (valid_ids - existing_ids).each_with_index do |rid, idx|
+        plant.plant_recipes.create!(recipe_id: rid, position: existing_ids.size + idx)
+      end
+      plant.sync_primary_recipe!
     end
 end

--- a/app/controllers/recipe_batches_controller.rb
+++ b/app/controllers/recipe_batches_controller.rb
@@ -1,12 +1,15 @@
 class RecipeBatchesController < ApplicationController
   before_action :authenticate
   before_action :ensure_project
-  before_action :set_recipe_batch, only: %i[show edit update destroy]
+  before_action :set_recipe_batch, only: %i[show edit update destroy adjust_remaining]
   before_action :authorize_viewer, only: [:index, :show, :for_recipe]
   before_action :authorize_editor, except: [:index, :show, :for_recipe]
 
   def index
-    @active_batches = current_project.recipe_batches.includes(:recipe).active.order(mixed_on: :desc)
+    urgency_order = { critical: 0, soon: 1, no_usage: 2, ok: 3 }
+    @active_batches = current_project.recipe_batches.includes(:recipe, :waterings).active
+                                     .order(mixed_on: :desc)
+                                     .sort_by { |b| urgency_order[b.replenishment_urgency] }
     @inactive_batches = current_project.recipe_batches.includes(:recipe).where(active: false).order(mixed_on: :desc)
   end
 
@@ -56,6 +59,25 @@ class RecipeBatchesController < ApplicationController
     end
   end
 
+  def adjust_remaining
+    volume = params[:volume].to_f
+    units = params[:units].presence || @recipe_batch.volume_units
+    action = params[:adjust_action]
+
+    if action == "add"
+      @recipe_batch.increment_remaining!(volume, units)
+    elsif action == "subtract"
+      @recipe_batch.decrement_remaining!(volume, units)
+    elsif action == "set"
+      @recipe_batch.update!(remaining_volume: volume, last_adjusted_at: Time.current)
+    end
+
+    respond_to do |format|
+      format.html { redirect_to @recipe_batch, notice: "Remaining volume updated." }
+      format.json { render json: { remaining_volume: @recipe_batch.remaining_volume } }
+    end
+  end
+
   def for_recipe
     batches = current_project.recipe_batches.active.where(recipe_id: params[:recipe_id])
     render json: batches.map { |b| { id: b.id, label: b.label, tds: b.tds } }
@@ -68,6 +90,6 @@ class RecipeBatchesController < ApplicationController
   end
 
   def recipe_batch_params
-    params.require(:recipe_batch).permit(:recipe_id, :tds, :volume, :volume_units, :mixed_on, :notes, :active, :project_id)
+    params.require(:recipe_batch).permit(:recipe_id, :tds, :volume, :volume_units, :mixed_on, :notes, :active, :project_id, :remaining_volume)
   end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,9 +1,9 @@
 class RecipesController < ApplicationController
   before_action :authenticate
   before_action :ensure_project
-  before_action :set_recipe, only: %i[show edit update destroy]
-  before_action :authorize_viewer, only: [:index, :show]
-  before_action :authorize_editor, except: [:index, :show]
+  before_action :set_recipe, only: %i[show edit update destroy calculate]
+  before_action :authorize_viewer, only: [:index, :show, :calculate]
+  before_action :authorize_editor, except: [:index, :show, :calculate]
 
   def index
     @recipes = current_project.recipes.includes(:recipe_sources, :recipe_batches)
@@ -46,6 +46,33 @@ class RecipesController < ApplicationController
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @recipe.errors, status: :unprocessable_entity }
       end
+    end
+  end
+
+  def calculate
+    volume = params[:volume].to_f
+    units = params[:units].presence || 'gal'
+    ref_volume = params[:reference_volume].to_f
+    ref_volume = 1.0 if ref_volume.zero?
+    ref_units = params[:reference_units].presence || 'gal'
+    target_conc = params[:concentration].presence
+    ref_conc = params[:reference_concentration].presence
+
+    calculator = RecipeCalculator.new(
+      @recipe,
+      target_volume: volume,
+      target_units: units,
+      reference_volume: ref_volume,
+      reference_units: ref_units,
+      target_concentration: target_conc,
+      reference_concentration: ref_conc
+    )
+    @results = calculator.calculate
+    @supported_units = RecipeCalculator.supported_units
+
+    respond_to do |format|
+      format.html
+      format.json { render json: { results: @results.map(&:to_h) } }
     end
   end
 

--- a/app/controllers/waterings_controller.rb
+++ b/app/controllers/waterings_controller.rb
@@ -17,7 +17,7 @@ class WateringsController < ApplicationController
   # GET /waterings/new
   def new
     @watering = Watering.new plant_id: params[:plant_id], watered_at: Time.zone.now, volume: params[:volume], units: params[:units], notes: params[:notes],
-      recipe_batch_id: params[:recipe_batch_id], recipe_id: params[:recipe_id], tds: params[:tds]
+      recipe_batch_id: params[:recipe_batch_id], recipe_id: params[:recipe_id], recipe_source_id: params[:recipe_source_id], tds: params[:tds]
 
     # Check for recent standalone moisture reading (within last hour) to pre-fill
     if @watering.plant
@@ -111,6 +111,6 @@ class WateringsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def watering_params
-      params.require(:watering).permit(:plant_id, :watered_at, :notes, :volume, :units, :tds, :recipe_batch_id, :recipe_id, :pre_moisture, :post_moisture, :pre_moisture_reading_id)
+      params.require(:watering).permit(:plant_id, :watered_at, :notes, :volume, :units, :tds, :recipe_batch_id, :recipe_id, :recipe_source_id, :pre_moisture, :post_moisture, :pre_moisture_reading_id)
     end
 end

--- a/app/javascript/controllers/recipe_calculator_controller.js
+++ b/app/javascript/controllers/recipe_calculator_controller.js
@@ -1,0 +1,59 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["volume", "units", "referenceVolume", "referenceUnits",
+                    "referenceConcentration", "targetConcentration", "results"]
+  static values = { url: String }
+
+  calculate() {
+    const volume = this.volumeTarget.value
+    if (!volume || parseFloat(volume) <= 0) {
+      this.resultsTarget.innerHTML = ""
+      return
+    }
+
+    const params = new URLSearchParams({
+      volume: volume,
+      units: this.unitsTarget.value,
+      reference_volume: this.referenceVolumeTarget.value || "1",
+      reference_units: this.referenceUnitsTarget.value,
+    })
+
+    if (this.referenceConcentrationTarget.value && this.targetConcentrationTarget.value) {
+      params.set("reference_concentration", this.referenceConcentrationTarget.value)
+      params.set("concentration", this.targetConcentrationTarget.value)
+    }
+
+    fetch(`${this.urlValue}?${params}`, {
+      headers: { "Accept": "application/json" }
+    })
+      .then(r => r.json())
+      .then(data => {
+        if (data.results && data.results.length > 0) {
+          this.renderResults(data.results)
+        } else {
+          this.resultsTarget.innerHTML = "<p>This recipe has no ingredients to calculate.</p>"
+        }
+      })
+      .catch(() => {
+        this.resultsTarget.innerHTML = "<p>Could not compute results.</p>"
+      })
+  }
+
+  renderResults(results) {
+    let html = `
+      <div class="calculator-results">
+        <h3>Ingredients Needed</h3>
+        <table class="timeline">
+          <thead><tr><th>Ingredient</th><th>Amount</th></tr></thead>
+          <tbody>
+    `
+    results.forEach(r => {
+      const amount = parseFloat(r.amount)
+      const formatted = amount % 1 === 0 ? amount.toString() : parseFloat(amount.toFixed(3)).toString()
+      html += `<tr><td>${r.source_name}</td><td>${formatted} ${r.units}</td></tr>`
+    })
+    html += `</tbody></table></div>`
+    this.resultsTarget.innerHTML = html
+  }
+}

--- a/app/javascript/controllers/smart_select_controller.js
+++ b/app/javascript/controllers/smart_select_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["chip", "select", "hidden", "details"]
+
+  pickSuggestion(event) {
+    const btn = event.currentTarget
+    const id = btn.dataset.id
+
+    this.hiddenTarget.value = id
+
+    this.chipTargets.forEach(c => c.classList.remove("selected"))
+    btn.classList.add("selected")
+
+    if (this.hasSelectTarget) {
+      this.selectTarget.value = id
+    }
+
+    this.dispatch("changed", { detail: { id } })
+  }
+
+  selectChanged() {
+    const id = this.selectTarget.value
+    this.hiddenTarget.value = id
+
+    this.chipTargets.forEach(c => {
+      c.classList.toggle("selected", c.dataset.id === id)
+    })
+
+    this.dispatch("changed", { detail: { id } })
+  }
+}

--- a/app/javascript/controllers/watering_recipe_controller.js
+++ b/app/javascript/controllers/watering_recipe_controller.js
@@ -1,14 +1,30 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["recipeSelect", "batchSelect", "tdsField", "tdsButton", "tdsContainer"]
+  static targets = ["sourceSelect", "recipeSection", "recipeSelect", "batchSelect",
+                    "tdsField", "tdsButton", "tdsContainer"]
   static values = { url: String }
 
+  sourceChanged() {
+    const sourceId = this.hasSourceSelectTarget ? this.sourceSelectTarget.value : null
+    if (this.hasRecipeSectionTarget) {
+      this.recipeSectionTarget.style.display = sourceId ? "none" : ""
+    }
+    if (sourceId && this.hasRecipeSelectTarget) {
+      this.recipeSelectTarget.value = ""
+      if (this.hasBatchSelectTarget) {
+        this.batchSelectTarget.innerHTML = '<option value="">-- None --</option>'
+      }
+    }
+  }
+
   recipeChanged() {
-    const recipeId = this.recipeSelectTarget.value
+    const recipeId = this.hasRecipeSelectTarget ? this.recipeSelectTarget.value : null
 
     if (!recipeId) {
-      this.batchSelectTarget.innerHTML = '<option value="">-- None --</option>'
+      if (this.hasBatchSelectTarget) {
+        this.batchSelectTarget.innerHTML = '<option value="">-- None --</option>'
+      }
       return
     }
 
@@ -19,11 +35,14 @@ export default class extends Controller {
         batches.forEach(batch => {
           options += `<option value="${batch.id}" data-tds="${batch.tds}">${batch.label}</option>`
         })
-        this.batchSelectTarget.innerHTML = options
+        if (this.hasBatchSelectTarget) {
+          this.batchSelectTarget.innerHTML = options
+        }
       })
   }
 
   batchChanged() {
+    if (!this.hasBatchSelectTarget) return
     const selected = this.batchSelectTarget.selectedOptions[0]
     if (selected && selected.dataset.tds) {
       this.tdsFieldTarget.value = selected.dataset.tds

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -3,7 +3,9 @@ class Plant < ApplicationRecord
 
   belongs_to :project
   belongs_to :location, optional: true
-  belongs_to :recipe, optional: true
+  belongs_to :recipe, optional: true  # primary recipe (cached for filtering/Ransack)
+  has_many :plant_recipes, -> { order(:position) }, dependent: :destroy
+  has_many :recipes, through: :plant_recipes
   has_one :zone, through: :location
   has_many :waterings, -> { order 'waterings.watered_at' }, dependent: :destroy
   belongs_to :last_watering, class_name: 'Watering', optional: true
@@ -12,6 +14,12 @@ class Plant < ApplicationRecord
 
   before_validation :strip_whitespace
   before_validation :set_default_max_watering_freq, on: :create
+
+  # Keep recipe_id in sync with the first plant_recipe entry
+  def sync_primary_recipe!
+    first_recipe = plant_recipes.order(:position).first&.recipe
+    update_column(:recipe_id, first_recipe&.id)
+  end
 
   validates_uniqueness_of :uid, scope: :project_id
 

--- a/app/models/plant_recipe.rb
+++ b/app/models/plant_recipe.rb
@@ -1,0 +1,6 @@
+class PlantRecipe < ApplicationRecord
+  belongs_to :plant
+  belongs_to :recipe
+
+  validates :recipe_id, uniqueness: { scope: :plant_id }
+end

--- a/app/models/recipe_batch.rb
+++ b/app/models/recipe_batch.rb
@@ -4,6 +4,7 @@ class RecipeBatch < ApplicationRecord
   has_many :waterings, dependent: :nullify
 
   validates :tds, presence: true, numericality: { greater_than: 0, only_integer: true }
+  validates :remaining_volume, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
   enum :volume_units, {
     'cups' => 0,
@@ -16,6 +17,8 @@ class RecipeBatch < ApplicationRecord
 
   scope :active, -> { where(active: true) }
 
+  USAGE_WINDOW_DAYS = 30
+
   def to_s
     "#{recipe.name} @ #{tds}ppm"
   end
@@ -23,5 +26,90 @@ class RecipeBatch < ApplicationRecord
   def label
     date_str = mixed_on ? mixed_on.strftime("%-b %-d") : created_at&.strftime("%-b %-d")
     "#{recipe.name} @ #{tds}ppm (#{date_str})"
+  end
+
+  def remaining_percent
+    return nil unless volume.present? && volume > 0 && remaining_volume.present?
+    (remaining_volume / volume * 100).round(1)
+  end
+
+  # Rolling usage per day over the last USAGE_WINDOW_DAYS days, in volume_units
+  def usage_per_day
+    recent = waterings
+      .where.not(volume: nil)
+      .where("watered_at >= ?", USAGE_WINDOW_DAYS.days.ago)
+
+    total_ml = recent.sum do |w|
+      convert_to_ml(w.volume, w.units)
+    end
+
+    batch_ml = convert_to_ml(1.0, volume_units) # 1 unit in volume_units -> mL
+    total_in_units = total_ml / batch_ml
+    total_in_units / USAGE_WINDOW_DAYS
+  end
+
+  # Returns projected run-out Date or nil if no usage data
+  def projected_runout
+    return nil unless remaining_volume.present? && remaining_volume > 0
+
+    rate = usage_per_day
+    return nil if rate.nil? || rate <= 0
+
+    days_left = remaining_volume / rate
+    Date.current + days_left.ceil.days
+  end
+
+  def replenishment_urgency
+    runout = projected_runout
+    return :no_usage unless runout
+
+    days = (runout - Date.current).to_i
+    if days <= 3
+      :critical
+    elsif days <= 7
+      :soon
+    else
+      :ok
+    end
+  end
+
+  def decrement_remaining!(volume_used, units_used)
+    return unless remaining_volume.present?
+
+    used_in_batch_units = convert_volume(volume_used.to_f, units_used, volume_units)
+    new_remaining = [remaining_volume - used_in_batch_units, 0].max
+    update!(remaining_volume: new_remaining, last_adjusted_at: Time.current)
+  end
+
+  def increment_remaining!(volume_added, units_added)
+    added_in_batch_units = convert_volume(volume_added.to_f, units_added, volume_units)
+    current = remaining_volume || 0
+    new_remaining = current + added_in_batch_units
+    new_remaining = [new_remaining, volume].min if volume.present?
+    update!(remaining_volume: new_remaining, last_adjusted_at: Time.current)
+  end
+
+  private
+
+  UNITS_TO_ML = {
+    'cups' => 236.588,
+    'oz'   => 29.5735,
+    'mL'   => 1.0,
+    'gal'  => 3785.41,
+    'qt'   => 946.353,
+    'L'    => 1000.0
+  }.freeze
+
+  def convert_to_ml(amount, units)
+    factor = UNITS_TO_ML[units.to_s]
+    return 0.0 unless factor
+    amount.to_f * factor
+  end
+
+  def convert_volume(amount, from_units, to_units)
+    ml = convert_to_ml(amount, from_units)
+    to_factor = UNITS_TO_ML[to_units.to_s]
+    return 0.0 unless to_factor
+    ml / to_factor
   end
 end

--- a/app/models/watering.rb
+++ b/app/models/watering.rb
@@ -14,6 +14,9 @@ class Watering < ApplicationRecord
   after_save_commit :update_last_watering
   after_destroy :update_last_watering
 
+  after_save_commit :adjust_batch_remaining_on_save
+  after_destroy :adjust_batch_remaining_on_destroy
+
   after_save :create_moisture_readings,
     if: -> { @pre_moisture.present? || @post_moisture.present? }
 
@@ -84,6 +87,33 @@ class Watering < ApplicationRecord
   attr_accessor :pre_moisture, :post_moisture, :pre_moisture_reading_id
 
   private
+
+  def adjust_batch_remaining_on_save
+    return unless recipe_batch.present? && volume.present?
+
+    if previous_changes[:recipe_batch_id]
+      old_batch_id = previous_changes[:recipe_batch_id].first
+      if old_batch_id.present?
+        old_batch = RecipeBatch.find_by(id: old_batch_id)
+        old_volume = previous_changes[:volume]&.first || volume
+        old_units = previous_changes[:units]&.first || units
+        old_batch&.increment_remaining!(old_volume, old_units)
+      end
+      recipe_batch.decrement_remaining!(volume, units)
+    elsif previous_changes[:id]
+      recipe_batch.decrement_remaining!(volume, units)
+    elsif previous_changes[:volume] || previous_changes[:units]
+      old_volume = previous_changes[:volume]&.first || volume
+      old_units = previous_changes[:units]&.first || units
+      recipe_batch.increment_remaining!(old_volume, old_units)
+      recipe_batch.decrement_remaining!(volume, units)
+    end
+  end
+
+  def adjust_batch_remaining_on_destroy
+    return unless recipe_batch.present? && volume.present?
+    recipe_batch.increment_remaining!(volume, units)
+  end
 
   def set_recipe_from_batch
     if recipe_batch.present? && recipe.blank?

--- a/app/models/watering.rb
+++ b/app/models/watering.rb
@@ -2,6 +2,7 @@ class Watering < ApplicationRecord
   belongs_to :plant
   belongs_to :recipe_batch, optional: true
   belongs_to :recipe, optional: true
+  belongs_to :recipe_source, optional: true
   has_many :soil_moisture_readings, dependent: :nullify
 
   validates :watered_at, presence: true
@@ -115,9 +116,22 @@ class Watering < ApplicationRecord
     recipe_batch.increment_remaining!(volume, units)
   end
 
+  def product_label
+    if recipe_batch.present?
+      recipe_batch.label
+    elsif recipe.present?
+      recipe.name
+    elsif recipe_source.present?
+      recipe_source.name
+    end
+  end
+
   def set_recipe_from_batch
     if recipe_batch.present? && recipe.blank?
       self.recipe = recipe_batch.recipe
+    end
+    if recipe_batch.present? || recipe.present?
+      self.recipe_source = nil
     end
   end
 

--- a/app/services/recipe_calculator.rb
+++ b/app/services/recipe_calculator.rb
@@ -1,0 +1,72 @@
+class RecipeCalculator
+  UNITS_TO_ML = {
+    'mL'   => 1.0,
+    'L'    => 1000.0,
+    'cups' => 236.588,
+    'oz'   => 29.5735,
+    'gal'  => 3785.41,
+    'qt'   => 946.353,
+    'tsp'  => 4.92892,
+    'tbsp' => 14.7868
+  }.freeze
+
+  Result = Struct.new(:ingredient_id, :source_name, :amount, :units, :error, keyword_init: true)
+
+  def initialize(recipe, target_volume:, target_units:,
+                 reference_volume: 1.0, reference_units: 'gal',
+                 target_concentration: nil, reference_concentration: nil)
+    @recipe = recipe
+    @target_volume = target_volume.to_f
+    @target_units = target_units
+    @reference_volume = reference_volume.to_f
+    @reference_units = reference_units
+    @target_concentration = target_concentration&.to_f
+    @reference_concentration = reference_concentration&.to_f
+  end
+
+  def calculate
+    return [] if @recipe.recipe_ingredients.empty?
+
+    vol_ratio = volume_ratio
+    conc_ratio = concentration_ratio
+    scale = vol_ratio * conc_ratio
+
+    @recipe.recipe_ingredients.includes(:recipe_source).map do |ingredient|
+      units = ingredient.units.presence || 'mL'
+      scaled = ingredient.amount.to_f * scale
+      Result.new(
+        ingredient_id: ingredient.id,
+        source_name: ingredient.recipe_source.name,
+        amount: scaled.round(4),
+        units: units,
+        error: nil
+      )
+    end
+  end
+
+  def self.supported_units
+    UNITS_TO_ML.keys
+  end
+
+  private
+
+  def volume_ratio
+    target_ml = to_ml(@target_volume, @target_units)
+    ref_ml = to_ml(@reference_volume, @reference_units)
+    return 1.0 if ref_ml.zero?
+    target_ml / ref_ml
+  end
+
+  def concentration_ratio
+    return 1.0 unless @target_concentration.present? &&
+                      @reference_concentration.present? &&
+                      @reference_concentration > 0
+    @target_concentration / @reference_concentration
+  end
+
+  def to_ml(amount, units)
+    factor = UNITS_TO_ML[units]
+    raise ArgumentError, "Unsupported unit: #{units}" unless factor
+    amount * factor
+  end
+end

--- a/app/services/smart_suggestions.rb
+++ b/app/services/smart_suggestions.rb
@@ -1,0 +1,100 @@
+class SmartSuggestions
+  Suggestion = Struct.new(:id, :label, :score, keyword_init: true)
+
+  def initialize(collection, scorer:, limit: 3)
+    @collection = collection
+    @scorer = scorer
+    @limit = limit
+  end
+
+  def top
+    scored = @collection.map do |item|
+      score = @scorer.call(item)
+      Suggestion.new(id: item.id, label: item.to_s, score: score)
+    end
+    scored.sort_by { |s| -s.score }.first(@limit)
+  end
+
+  def rest(top_ids)
+    @collection.reject { |item| top_ids.include?(item.id) }
+  end
+
+  # ─── Pre-built scorers ─────────────────────────────────────────────────────
+
+  # Most recently used location (by last plant added)
+  def self.location_scorer(project)
+    recent_location_ids = project.plants
+      .where.not(location_id: nil)
+      .order(created_at: :desc)
+      .limit(50)
+      .pluck(:location_id)
+
+    usage_counts = recent_location_ids.tally
+    max_count = usage_counts.values.max || 1
+
+    recency_bonus = {}
+    recent_location_ids.each_with_index do |loc_id, idx|
+      recency_bonus[loc_id] ||= (50 - idx).to_f / 50
+    end
+
+    ->(location) {
+      count_score = (usage_counts[location.id] || 0).to_f / max_count
+      recency_bonus[location.id].to_f + count_score
+    }
+  end
+
+  # Most commonly used recipes (by active plant count, then recent batch count)
+  def self.recipe_scorer(project)
+    plant_counts = project.plants.where.not(recipe_id: nil).group(:recipe_id).count
+    batch_counts = project.recipe_batches.active.group(:recipe_id).count
+    max_plants = plant_counts.values.max || 1
+
+    ->(recipe) {
+      plant_score = (plant_counts[recipe.id] || 0).to_f / max_plants
+      batch_bonus = batch_counts[recipe.id].present? ? 0.5 : 0.0
+      plant_score + batch_bonus
+    }
+  end
+
+  # Most commonly mixed recipes (by batch count, recency-weighted)
+  def self.recipe_batch_scorer(project)
+    batches = project.recipe_batches.order(mixed_on: :desc).limit(50)
+    recipe_counts = batches.group_by(&:recipe_id).transform_values(&:count)
+    max_count = recipe_counts.values.max || 1
+
+    recent_recipe_ids = batches.pluck(:recipe_id).uniq
+    recency_bonus = recent_recipe_ids.each_with_index.to_h { |rid, idx| [rid, (10 - idx).to_f / 10] }
+
+    has_active_batch = project.recipe_batches.active.pluck(:recipe_id).to_set
+
+    ->(recipe) {
+      count_score = (recipe_counts[recipe.id] || 0).to_f / max_count
+      recency = recency_bonus[recipe.id].to_f
+      # Boost recipes with NO active batch (next to be mixed)
+      no_batch_bonus = has_active_batch.include?(recipe.id) ? 0.0 : 0.3
+      count_score + recency + no_batch_bonus
+    }
+  end
+
+  # Most recent active batches for a given recipe
+  def self.batch_scorer_for_recipe(recipe_id)
+    ->(batch) {
+      return 0.0 unless batch.recipe_id == recipe_id
+      days_old = batch.mixed_on ? [(Date.current - batch.mixed_on).to_i, 0].max : 365
+      [1.0 - days_old.to_f / 365, 0.0].max
+    }
+  end
+
+  # Plant's own recipes at top, then previously-used recipes for this plant
+  def self.watering_recipe_scorer(plant)
+    plant_recipe_ids = plant.plant_recipes.pluck(:recipe_id).to_set
+    recent_recipe_ids = plant.waterings.where.not(recipe_id: nil)
+                             .order(watered_at: :desc).limit(20).pluck(:recipe_id)
+    recency = recent_recipe_ids.each_with_index.to_h { |rid, idx| [rid, (20 - idx).to_f / 20] }
+
+    ->(recipe) {
+      primary_bonus = plant_recipe_ids.include?(recipe.id) ? 2.0 : 0.0
+      primary_bonus + recency[recipe.id].to_f
+    }
+  end
+end

--- a/app/views/plants/_form.html.erb
+++ b/app/views/plants/_form.html.erb
@@ -39,11 +39,25 @@
     <%= form.hidden_field :uid %>
   <% end %>
 
-  <% locations = current_project.locations %>
+  <% locations = current_project.locations.order(:name) %>
   <% unless locations.empty? %>
     <div class="field">
-      <%= form.label :location_id, "📍 #{t('attributes.location')}" %>
-      <%= form.collection_select :location_id, locations, :id, :name %>
+      <% loc_scorer = SmartSuggestions.location_scorer(current_project) %>
+      <% loc_suggestions_svc = SmartSuggestions.new(locations, scorer: loc_scorer, limit: 3) %>
+      <% loc_top = loc_suggestions_svc.top %>
+      <% if loc_top.any? %>
+        <%= render 'shared/smart_select',
+            field_name: "plant[location_id]",
+            field_id: "plant_location_id",
+            label: "📍 #{t('attributes.location')}",
+            suggestions: loc_top,
+            all_items: locations,
+            selected_id: plant.location_id,
+            prompt: "-- None --" %>
+      <% else %>
+        <%= form.label :location_id, "📍 #{t('attributes.location')}" %>
+        <%= form.collection_select :location_id, locations, :id, :name, include_blank: '-- None --' %>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/views/plants/_form.html.erb
+++ b/app/views/plants/_form.html.erb
@@ -47,11 +47,21 @@
     </div>
   <% end %>
 
-  <% recipes = current_project.recipes %>
+  <% recipes = current_project.recipes.order(:name) %>
   <% unless recipes.empty? %>
     <div class="field">
-      <%= form.label :recipe_id, "🧪 Recipe" %>
-      <%= form.collection_select :recipe_id, recipes.order(:name), :id, :name, include_blank: '-- None --' %>
+      <label>🧪 Recipes</label>
+      <div class="recipe-checkboxes">
+        <% recipes.each do |recipe| %>
+          <label class="checkbox-label">
+            <input type="checkbox" name="plant[recipe_ids][]"
+                   value="<%= recipe.id %>"
+                   <%= 'checked' if plant.recipes.map(&:id).include?(recipe.id) %>>
+            <%= recipe.name %>
+          </label>
+        <% end %>
+      </div>
+      <small>Select zero or more recipes. The first selected recipe is used for filtering.</small>
     </div>
   <% end %>
 

--- a/app/views/plants/_plant.html.erb
+++ b/app/views/plants/_plant.html.erb
@@ -48,7 +48,9 @@
           <% if @plant.last_watering&.notes.present? %>
             <span class="watering-notes-text">📝 <%= @plant.last_watering.notes %></span>
           <% end %>
-          <% if @plant.last_watering&.recipe.present? %>
+          <% if @plant.last_watering&.recipe_source.present? %>
+            <span class="watering-recipe-text">💧 <%= @plant.last_watering.recipe_source.name %></span>
+          <% elsif @plant.last_watering&.recipe.present? %>
             <span class="watering-recipe-text">🧪 <%= @plant.last_watering.recipe.name %></span>
           <% end %>
           <% if @plant.last_watering&.recipe_batch.present? %>
@@ -88,10 +90,15 @@
           <span class="value"><%= plant.pot %></span>
         </div>
       <% end %>
-      <% if plant.recipe.present? %>
+      <% plant_recipe_list = plant.plant_recipes.includes(:recipe).map(&:recipe) %>
+      <% if plant_recipe_list.any? %>
         <div class="info-row">
-          <span class="label">🧪 Recipe:</span>
-          <span class="value"><%= link_to plant.recipe.name, recipe_path(plant.recipe) %></span>
+          <span class="label">🧪 <%= plant_recipe_list.size == 1 ? 'Recipe' : 'Recipes' %>:</span>
+          <span class="value">
+            <% plant_recipe_list.each_with_index do |r, i| %>
+              <%= link_to r.name, recipe_path(r) %><%= i < plant_recipe_list.size - 1 ? ', ' : '' %>
+            <% end %>
+          </span>
         </div>
       <% end %>
       <% if @plant.archived %>

--- a/app/views/plants/_timeline.html.erb
+++ b/app/views/plants/_timeline.html.erb
@@ -26,6 +26,7 @@
           <% if watering.volume.present? %><strong><%= watering.print_volume %></strong><% else %><span class='no-volume'>—</span><% end %>
           <% if watering.notes.present? %><span class='watering-notes'><%= watering.notes %></span><% end %>
           <% if watering.tds.present? %><span class='watering-tds'>📊 <%= watering.tds %>ppm</span><% end %>
+          <% if watering.recipe_source.present? %><span class='watering-recipe'>💧 <%= watering.recipe_source.name %></span><% end %>
           <% if watering.recipe.present? %><span class='watering-recipe'>🧪 <%= watering.recipe.name %></span><% end %>
           <% if watering.recipe_batch.present? %><span class='watering-batch'>🪣 <%= watering.recipe_batch.to_s %></span><% end %>
           <% if watering.soil_moisture_readings.any? %>

--- a/app/views/recipe_batches/_form.html.erb
+++ b/app/views/recipe_batches/_form.html.erb
@@ -38,6 +38,12 @@
   </div>
 
   <div>
+    <%= form.label :remaining_volume, "Remaining Volume (optional)", style: "display: block" %>
+    <%= form.number_field :remaining_volume, step: 'any', placeholder: "Leave blank to track manually" %>
+    <small>How much is currently in this batch. Defaults to full volume if left blank.</small>
+  </div>
+
+  <div>
     <%= form.label :notes, style: "display: block" %>
     <%= form.textarea :notes %>
   </div>

--- a/app/views/recipe_batches/index.html.erb
+++ b/app/views/recipe_batches/index.html.erb
@@ -6,6 +6,7 @@
   <h2>Active</h2>
   <div class="resource-cards">
     <% @active_batches.each do |batch| %>
+      <% urgency = batch.replenishment_urgency %>
       <div class="info-card">
         <div class="info-card-grid">
           <div class="info-card-section" style="background: color-mix(in srgb, <%= batch.recipe.hex_color %> 12%, transparent); border-left: 3px solid color-mix(in srgb, <%= batch.recipe.hex_color %> 80%, black);">
@@ -25,6 +26,30 @@
               <div class="info-row">
                 <span class="label">Volume</span>
                 <span class="value"><%= sprintf('%g', batch.volume) %> <%= batch.volume_units %></span>
+              </div>
+            <% end %>
+            <% if batch.remaining_volume.present? %>
+              <div class="info-row">
+                <span class="label">Remaining</span>
+                <span class="value">
+                  <%= sprintf('%g', batch.remaining_volume.round(3)) %> <%= batch.volume_units %>
+                  <% if batch.remaining_percent %>
+                    (<%= batch.remaining_percent %>%)
+                  <% end %>
+                </span>
+              </div>
+              <div class="info-row">
+                <span class="label">Runs Out</span>
+                <span class="value">
+                  <% runout = batch.projected_runout %>
+                  <% if runout %>
+                    <span style="<%= urgency == :critical ? 'color: #c62828; font-weight: 600;' : urgency == :soon ? 'color: #e65100;' : '' %>">
+                      ~<%= format_date runout %> (<%= (runout - Date.current).to_i %> days)
+                    </span>
+                  <% else %>
+                    <span style="color: #666;">No recent usage</span>
+                  <% end %>
+                </span>
               </div>
             <% end %>
             <% if batch.mixed_on.present? %>

--- a/app/views/recipe_batches/show.html.erb
+++ b/app/views/recipe_batches/show.html.erb
@@ -29,6 +29,28 @@
           <span class="value"><%= format_date @recipe_batch.mixed_on %></span>
         </div>
       <% end %>
+      <% if @recipe_batch.remaining_volume.present? %>
+        <div class="info-row">
+          <span class="label">Remaining</span>
+          <span class="value">
+            <%= sprintf('%g', @recipe_batch.remaining_volume.round(3)) %> <%= @recipe_batch.volume_units %>
+            <% if @recipe_batch.remaining_percent %>
+              (<%= @recipe_batch.remaining_percent %>%)
+            <% end %>
+          </span>
+        </div>
+        <% runout = @recipe_batch.projected_runout %>
+        <div class="info-row">
+          <span class="label">Runs Out</span>
+          <span class="value">
+            <% if runout %>
+              ~<%= format_date runout %> (<%= (runout - Date.current).to_i %> days)
+            <% else %>
+              No recent usage
+            <% end %>
+          </span>
+        </div>
+      <% end %>
       <div class="info-row">
         <span class="label">Status</span>
         <span class="value"><%= @recipe_batch.active? ? "Active" : "Inactive" %></span>
@@ -41,6 +63,24 @@
       <% end %>
     </div>
   </div>
+</div>
+
+<div class="settings-card">
+  <h3>Adjust Remaining Volume</h3>
+  <%= form_with url: adjust_remaining_recipe_batch_path(@recipe_batch), method: :patch, data: { turbo: false } do |f| %>
+    <div class="field-row">
+      <div class="field-row-item">
+        <%= f.number_field :volume, step: 'any', placeholder: "e.g. 1.5", id: "adjust_volume" %>
+      </div>
+      <div class="field-row-item">
+        <%= f.select :units, options_for_select(RecipeBatch.volume_units.map { |k, v| [k, k] }, @recipe_batch.volume_units), {}, { id: "adjust_units" } %>
+      </div>
+      <div class="field-row-item">
+        <%= f.select :adjust_action, [["➕ Add", "add"], ["➖ Subtract", "subtract"], ["Set to", "set"]] %>
+      </div>
+    </div>
+    <%= f.submit "Update Remaining", class: 'saveButton' %>
+  <% end %>
 </div>
 
 <div>

--- a/app/views/recipes/_calculator_result.html.erb
+++ b/app/views/recipes/_calculator_result.html.erb
@@ -1,0 +1,23 @@
+<% if results.any? %>
+  <div class="calculator-results">
+    <h3>Ingredients Needed</h3>
+    <table class="timeline">
+      <thead>
+        <tr>
+          <th>Ingredient</th>
+          <th>Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% results.each do |r| %>
+          <tr>
+            <td><%= r.source_name %></td>
+            <td><%= sprintf('%g', r.amount.round(3)) %> <%= r.units %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% elsif results.empty? && defined?(show_empty) && show_empty %>
+  <p class="empty-state">This recipe has no ingredients to calculate.</p>
+<% end %>

--- a/app/views/recipes/calculate.html.erb
+++ b/app/views/recipes/calculate.html.erb
@@ -1,0 +1,83 @@
+<% content_for :title, "Calculator: #{@recipe}" %>
+
+<h1>
+  <%= link_to "Recipes", recipes_path, class: 'breadcrumb' %>
+  <%= icon 'chevron-right', variant: 'mini', class: 'breadcrumb' %>
+  <%= link_to @recipe.name, recipe_path(@recipe), class: 'breadcrumb' %>
+  <%= icon 'chevron-right', variant: 'mini', class: 'breadcrumb' %>
+  Calculator
+</h1>
+
+<div class="settings-card"
+     data-controller="recipe-calculator"
+     data-recipe-calculator-url-value="<%= calculate_recipe_path(@recipe, format: :json) %>">
+
+  <h2>Batch Calculator</h2>
+
+  <div class="field-row">
+    <div class="field-row-item">
+      <label>Target Volume</label>
+      <input type="number" step="any" placeholder="e.g. 5.0" min="0"
+             data-recipe-calculator-target="volume"
+             data-action="input->recipe-calculator#calculate">
+    </div>
+    <div class="field-row-item">
+      <label>Units</label>
+      <select data-recipe-calculator-target="units"
+              data-action="change->recipe-calculator#calculate">
+        <% @supported_units.each do |unit| %>
+          <option value="<%= unit %>" <%= 'selected' if unit == 'gal' %>><%= unit %></option>
+        <% end %>
+      </select>
+    </div>
+  </div>
+
+  <details>
+    <summary class="buttonLink" style="display: inline-block; margin-bottom: 0.5rem;">Reference / Concentration Options</summary>
+    <div style="margin-top: 0.5rem;">
+      <div class="field-row">
+        <div class="field-row-item">
+          <label>Reference Volume</label>
+          <input type="number" step="any" value="1" min="0"
+                 data-recipe-calculator-target="referenceVolume"
+                 data-action="input->recipe-calculator#calculate">
+        </div>
+        <div class="field-row-item">
+          <label>Reference Units</label>
+          <select data-recipe-calculator-target="referenceUnits"
+                  data-action="change->recipe-calculator#calculate">
+            <% @supported_units.each do |unit| %>
+              <option value="<%= unit %>" <%= 'selected' if unit == 'gal' %>><%= unit %></option>
+            <% end %>
+          </select>
+        </div>
+      </div>
+
+      <div class="field-row">
+        <div class="field-row-item">
+          <label>Reference Concentration (ppm)</label>
+          <input type="number" step="1" placeholder="e.g. 400" min="0"
+                 data-recipe-calculator-target="referenceConcentration"
+                 data-action="input->recipe-calculator#calculate">
+        </div>
+        <div class="field-row-item">
+          <label>Target Concentration (ppm)</label>
+          <input type="number" step="1" placeholder="e.g. 800" min="0"
+                 data-recipe-calculator-target="targetConcentration"
+                 data-action="input->recipe-calculator#calculate">
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <div data-recipe-calculator-target="results" style="margin-top: 1rem;">
+    <% if params[:volume].present? %>
+      <%= render 'calculator_result', results: @results %>
+    <% end %>
+  </div>
+</div>
+
+<div>
+  <%= link_to "↩️ Back to Recipe", recipe_path(@recipe), class: 'link' %>
+  <%= link_to "➕ New Batch", new_recipe_batch_path(recipe_id: @recipe.id), class: 'link' %>
+</div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -38,6 +38,7 @@
 <% end %>
 
 <div>
+  <%= link_to "🧮 Calculator", calculate_recipe_path(@recipe), class: 'link' %>
   <%= link_to "✏️ Edit this Recipe", edit_recipe_path(@recipe), class: 'link' %>
   <%= link_to "↩️ Back to Recipes", recipes_path, class: 'link' %>
 </div>

--- a/app/views/shared/_smart_select.html.erb
+++ b/app/views/shared/_smart_select.html.erb
@@ -1,0 +1,54 @@
+<%#
+  Renders a smart select field with top suggestions shown prominently
+  and the full list in a collapsible "Show all" section.
+
+  Locals:
+    field_name  - form field name, e.g. "plant[location_id]"
+    field_id    - HTML id for the select element
+    label       - label text
+    suggestions - array of SmartSuggestions::Suggestion (id, label, score)
+    all_items   - full AR collection / array (responds to .id and .to_s)
+    selected_id - currently selected id (integer or nil)
+    prompt      - placeholder text (default: "-- Select --")
+    include_blank - whether to include a blank option in full list
+%>
+<% prompt ||= "-- Select --" %>
+<% include_blank ||= true %>
+
+<div class="smart-select" data-controller="smart-select">
+  <label><%= label %></label>
+
+  <% if suggestions.any? %>
+    <div class="smart-select-suggestions">
+      <span class="suggestions-label">Suggested:</span>
+      <% suggestions.each do |s| %>
+        <button type="button"
+                class="suggestion-chip<%= ' selected' if s.id == selected_id %>"
+                data-action="click->smart-select#pickSuggestion"
+                data-smart-select-target="chip"
+                data-id="<%= s.id %>"
+                data-field-id="<%= field_id %>">
+          <%= s.label %>
+        </button>
+      <% end %>
+    </div>
+  <% end %>
+
+  <details data-smart-select-target="details">
+    <summary class="buttonLinkSmall">Show all &darr;</summary>
+    <select name="<%= field_name %>" id="<%= field_id %>"
+            data-smart-select-target="select"
+            data-action="change->smart-select#selectChanged">
+      <% if include_blank %>
+        <option value=""><%= prompt %></option>
+      <% end %>
+      <% all_items.each do |item| %>
+        <option value="<%= item.id %>" <%= 'selected' if item.id == selected_id %>><%= item.to_s %></option>
+      <% end %>
+    </select>
+  </details>
+
+  <input type="hidden" name="<%= field_name %>" id="<%= field_id %>_hidden"
+         value="<%= selected_id %>"
+         data-smart-select-target="hidden">
+</div>

--- a/app/views/waterings/_form.html.erb
+++ b/app/views/waterings/_form.html.erb
@@ -1,4 +1,4 @@
-  <%= form_with(model: watering, data: { controller: "watering-recipe watering-moisture", watering_recipe_url_value: for_recipe_recipe_batches_path, turbo: false }) do |form| %>
+  <%= form_with(model: watering, data: { controller: "watering-moisture", turbo: false }) do |form| %>
     <% if watering.errors.any? %>
       <div style="color: red">
         <h2><%= pluralize(watering.errors.count, "error") %> prohibited this watering from being saved:</h2>
@@ -35,40 +35,60 @@
       </div>
     </div>
 
-    <% if current_project.recipes.any? %>
-      <div class="field-row">
-        <div class="field-row-item">
-          <%= form.label :recipe_id, "Recipe", style: "display: block" %>
-          <%= form.collection_select :recipe_id, current_project.recipes.order(:name), :id, :name, { prompt: '-- None --', selected: watering.recipe_id }, { data: { watering_recipe_target: "recipeSelect", action: "change->watering-recipe#recipeChanged" } } %>
-        </div>
-        <div class="field-row-item">
-          <%= form.label :recipe_batch_id, "Batch", style: "display: block" %>
-          <select name="watering[recipe_batch_id]" id="watering_recipe_batch_id" data-watering-recipe-target="batchSelect" data-action="change->watering-recipe#batchChanged">
-            <option value="">-- None --</option>
-            <% if watering.recipe_id.present? %>
-              <% current_project.recipe_batches.active.where(recipe_id: watering.recipe_id).each do |batch| %>
-                <option value="<%= batch.id %>" data-tds="<%= batch.tds %>" <%= 'selected' if watering.recipe_batch_id == batch.id %>><%= batch.label %></option>
-              <% end %>
-            <% end %>
-          </select>
-        </div>
-      </div>
+    <% has_recipes = current_project.recipes.any? %>
+    <% has_sources = current_project.recipe_sources.any? %>
+    <% if has_recipes || has_sources %>
+      <div data-controller="watering-recipe"
+           data-watering-recipe-url-value="<%= for_recipe_recipe_batches_path %>">
 
-      <div>
-        <button type="button"
-                data-action="click->watering-recipe#toggleTds"
-                data-watering-recipe-target="tdsButton"
-                class="buttonLink"
-                style="<%= 'display: none;' if watering.tds.present? %>">
-          ➕ Add TDS
-        </button>
-        <div data-watering-recipe-target="tdsContainer" style="<%= watering.tds.present? ? 'display: block;' : 'display: none;' %>">
-          <%= form.label :tds, "TDS (ppm)", style: "display: block" %>
-          <div style="display: flex; align-items: center; gap: 0.5rem;">
-            <%= form.number_field :tds, placeholder: "e.g. 400", data: { watering_recipe_target: "tdsField" } %>
-            <button type="button"
-                    data-action="click->watering-recipe#hideTds"
-                    class="buttonLinkSmall">✕ Remove TDS</button>
+        <div style="margin-bottom: 0.5rem;">
+          <%= form.label :recipe_source_id, "Source (water type)", style: "display: block" %>
+          <%= form.collection_select :recipe_source_id, current_project.recipe_sources.order(:name), :id, :name,
+              { prompt: '-- None (use recipe below) --', selected: watering.recipe_source_id },
+              { data: { watering_recipe_target: "sourceSelect", action: "change->watering-recipe#sourceChanged" } } %>
+        </div>
+
+        <% if has_recipes %>
+          <div class="field-row" data-watering-recipe-target="recipeSection"
+               style="<%= watering.recipe_source_id.present? ? 'display: none;' : '' %>">
+            <div class="field-row-item">
+              <%= form.label :recipe_id, "Recipe", style: "display: block" %>
+              <%= form.collection_select :recipe_id, current_project.recipes.order(:name), :id, :name,
+                  { prompt: '-- None --', selected: watering.recipe_id },
+                  { data: { watering_recipe_target: "recipeSelect", action: "change->watering-recipe#recipeChanged" } } %>
+            </div>
+            <div class="field-row-item">
+              <%= form.label :recipe_batch_id, "Batch", style: "display: block" %>
+              <select name="watering[recipe_batch_id]" id="watering_recipe_batch_id"
+                      data-watering-recipe-target="batchSelect"
+                      data-action="change->watering-recipe#batchChanged">
+                <option value="">-- None --</option>
+                <% if watering.recipe_id.present? %>
+                  <% current_project.recipe_batches.active.where(recipe_id: watering.recipe_id).each do |batch| %>
+                    <option value="<%= batch.id %>" data-tds="<%= batch.tds %>" <%= 'selected' if watering.recipe_batch_id == batch.id %>><%= batch.label %></option>
+                  <% end %>
+                <% end %>
+              </select>
+            </div>
+          </div>
+        <% end %>
+
+        <div>
+          <button type="button"
+                  data-action="click->watering-recipe#toggleTds"
+                  data-watering-recipe-target="tdsButton"
+                  class="buttonLink"
+                  style="<%= 'display: none;' if watering.tds.present? %>">
+            ➕ Add TDS
+          </button>
+          <div data-watering-recipe-target="tdsContainer" style="<%= watering.tds.present? ? 'display: block;' : 'display: none;' %>">
+            <%= form.label :tds, "TDS (ppm)", style: "display: block" %>
+            <div style="display: flex; align-items: center; gap: 0.5rem;">
+              <%= form.number_field :tds, placeholder: "e.g. 400", data: { watering_recipe_target: "tdsField" } %>
+              <button type="button"
+                      data-action="click->watering-recipe#hideTds"
+                      class="buttonLinkSmall">✕ Remove TDS</button>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/waterings/_watering.html.erb
+++ b/app/views/waterings/_watering.html.erb
@@ -14,17 +14,24 @@
     <span class="value"><%= watering.print_volume %></span>
   </div>
 
+  <% if watering.recipe_source.present? %>
+    <div class="info-row">
+      <strong>Source</strong>
+      <span class="value"><%= link_to watering.recipe_source.name, recipe_source_path(watering.recipe_source) %></span>
+    </div>
+  <% end %>
+
   <% if watering.recipe.present? %>
     <div class="info-row">
       <strong>Recipe</strong>
-      <span class="value"><%= watering.recipe.name %></span>
+      <span class="value"><%= link_to watering.recipe.name, recipe_path(watering.recipe) %></span>
     </div>
   <% end %>
 
   <% if watering.recipe_batch.present? %>
     <div class="info-row">
       <strong>Batch</strong>
-      <span class="value"><%= watering.recipe_batch.label %></span>
+      <span class="value"><%= link_to watering.recipe_batch.label, recipe_batch_path(watering.recipe_batch) %></span>
     </div>
   <% end %>
 

--- a/claude-sprint
+++ b/claude-sprint
@@ -13,7 +13,7 @@ set -euo pipefail
 REPO_DIR="$HOME/autofauna"
 REPO="jefamirault/autofauna"
 SESSION="claude-sprint"
-NUM_WORKERS=4
+NUM_WORKERS=0  # 0 = auto-detect from label count
 DRY_RUN=false
 CLEANUP=false
 MILESTONE=""
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
       echo "       ./claude-sprint --cleanup [<milestone>]"
       echo ""
       echo "  <milestone>   GitHub milestone title (required for launch, optional for cleanup)"
-      echo "  --agents N    Number of worker agents (default: 4)"
+      echo "  --agents N    Number of worker agents (default: auto from label count)"
       echo "  --dry-run     Show plan without launching tmux/claude"
       echo "  --cleanup     Remove worktrees, branches, and databases from a sprint"
       exit 0
@@ -79,11 +79,20 @@ if [ "$CLEANUP" = true ]; then
   fi
 
   if [ -n "$branches" ]; then
-    echo "Removing branches..."
+    echo "Removing local branches..."
     while IFS= read -r branch; do
       [ -z "$branch" ] && continue
-      echo "  Deleting branch: $branch"
+      echo "  Deleting local branch: $branch"
       git -C "$REPO_DIR" branch -D "$branch" 2>/dev/null || true
+    done <<< "$branches"
+
+    echo "Removing remote branches..."
+    while IFS= read -r branch; do
+      [ -z "$branch" ] && continue
+      if git -C "$REPO_DIR" ls-remote --exit-code --heads origin "$branch" &>/dev/null; then
+        echo "  Deleting remote branch: $branch"
+        git -C "$REPO_DIR" push origin --delete "$branch" 2>/dev/null || echo "    WARNING: Failed to delete remote branch $branch"
+      fi
     done <<< "$branches"
   fi
 
@@ -177,6 +186,13 @@ done
 declare -a worker_assignments=()
 declare -a worker_labels=()
 
+# When auto-detecting, allow unlimited groups (one per label); will be finalized later
+AUTO_DETECT=false
+if [ "$NUM_WORKERS" -eq 0 ]; then
+  AUTO_DETECT=true
+  NUM_WORKERS=999
+fi
+
 while IFS= read -r label; do
   [ -z "$label" ] && continue
   if [ ${#worker_assignments[@]} -lt "$NUM_WORKERS" ]; then
@@ -202,9 +218,13 @@ for issue_num in "${unlabeled_issues[@]}"; do
   worker_idx=$(( (worker_idx + 1) % NUM_WORKERS ))
 done
 
-# Cap NUM_WORKERS to actual number of workers with issues (no empty panes)
+# Set NUM_WORKERS: auto-detect from assignments if not explicitly set, otherwise cap to actual count
 actual_workers=${#worker_assignments[@]}
-if [ "$actual_workers" -lt "$NUM_WORKERS" ]; then
+if [ "$AUTO_DETECT" = true ]; then
+  NUM_WORKERS=$actual_workers
+  echo "Auto-detected $NUM_WORKERS worker(s) from label groups."
+elif [ "$actual_workers" -lt "$NUM_WORKERS" ]; then
+  echo "Capping workers from $NUM_WORKERS to $actual_workers (not enough label groups)."
   NUM_WORKERS=$actual_workers
 fi
 
@@ -348,6 +368,12 @@ $manager_issues_summary
 - Use \`gh\` commands to communicate with workers via issue comments
 - If a worker needs to modify a file another worker owns, coordinate via issue comments first
 - Keep the agent_log.md updated with sprint progress
+
+## Direct Worktree Edits (Fallback)
+If a worker has exited or is unresponsive, you can make edits directly in their worktree. Worker worktree paths follow the pattern:
+  \`$REPO_DIR-<branch-with-slashes-as-dashes>\`
+For example, branch \`sprint/0-9-1/plant-management\` → \`$REPO_DIR-sprint-0-9-1-plant-management\`
+You can edit files, commit, and push from these directories. Use this as a fallback when quick revisions are needed and the worker is unavailable.
 PROMPT
 )
 
@@ -416,7 +442,8 @@ $issue_details
 3. **Do not modify** files outside your scope without coordinating (check issue comments for guidance from the manager)
 4. **Read CLAUDE.md** for project conventions before starting
 5. **Run tests** after each significant change
-6. When done with all issues, commit your work and notify by commenting on the issues: \`gh issue comment <number> --repo $REPO --body "Implementation complete on branch ${branch_names[$i]}"\`
+6. When done with all issues, commit and push your work, then notify by commenting on the issues: \`gh issue comment <number> --repo $REPO --body "Implementation complete on branch ${branch_names[$i]}"\`
+7. **Stay alive after completing work** — do NOT exit after finishing. Report completion and then wait for revision requests. The manager or user may request changes via issue comments or direct messages. Periodically check for new comments on your issues: \`gh issue view <number> --repo $REPO --comments\`
 
 ## Getting Started
 1. Read CLAUDE.md for project conventions
@@ -424,6 +451,7 @@ $issue_details
 3. Plan your implementation approach
 4. Implement one issue at a time, committing after each
 5. Run tests to verify nothing is broken
+6. After all issues are done, push your branch and stay available for revisions
 PROMPT
 )
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,10 +19,17 @@ Rails.application.routes.draw do
 
   resources :locations
   resources :recipe_sources
-  resources :recipes
+  resources :recipes do
+    member do
+      get :calculate
+    end
+  end
   resources :recipe_batches do
     collection do
       get :for_recipe
+    end
+    member do
+      patch :adjust_remaining
     end
   end
   resources :tanks do

--- a/db/migrate/20260424100001_add_remaining_volume_to_recipe_batches.rb
+++ b/db/migrate/20260424100001_add_remaining_volume_to_recipe_batches.rb
@@ -1,0 +1,6 @@
+class AddRemainingVolumeToRecipeBatches < ActiveRecord::Migration[8.0]
+  def change
+    add_column :recipe_batches, :remaining_volume, :float
+    add_column :recipe_batches, :last_adjusted_at, :datetime
+  end
+end

--- a/db/migrate/20260424100002_add_recipe_source_to_waterings.rb
+++ b/db/migrate/20260424100002_add_recipe_source_to_waterings.rb
@@ -1,0 +1,5 @@
+class AddRecipeSourceToWaterings < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :waterings, :recipe_source, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20260424100003_create_plant_recipes.rb
+++ b/db/migrate/20260424100003_create_plant_recipes.rb
@@ -1,0 +1,27 @@
+class CreatePlantRecipes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :plant_recipes do |t|
+      t.references :plant, null: false, foreign_key: true
+      t.references :recipe, null: false, foreign_key: true
+      t.integer :position, default: 0
+      t.timestamps
+    end
+
+    add_index :plant_recipes, [:plant_id, :recipe_id], unique: true
+
+    # Migrate existing recipe_id values from plants into the join table
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          INSERT INTO plant_recipes (plant_id, recipe_id, position, created_at, updated_at)
+          SELECT id, recipe_id, 0, NOW(), NOW()
+          FROM plants
+          WHERE recipe_id IS NOT NULL
+        SQL
+      end
+    end
+
+    # Keep recipe_id on plants for now as a cached "primary recipe" reference
+    # (used by Ransack filters and existing index queries)
+  end
+end

--- a/test/fixtures/plant_recipes.yml
+++ b/test/fixtures/plant_recipes.yml
@@ -1,0 +1,2 @@
+# Plant recipes fixtures — kept minimal since there are no recipe fixtures
+# Tests that need plant_recipes should create them inline

--- a/test/models/recipe_batch_test.rb
+++ b/test/models/recipe_batch_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class RecipeBatchTest < ActiveSupport::TestCase
+  setup do
+    @project = Project.create!(name: "Batch Test", owner: users(:one))
+    @recipe = Recipe.create!(name: "High N", project: @project)
+    @batch = RecipeBatch.create!(
+      project: @project,
+      recipe: @recipe,
+      tds: 400,
+      volume: 10.0,
+      volume_units: "gal",
+      remaining_volume: 10.0,
+      mixed_on: Date.current
+    )
+  end
+
+  test "decrement_remaining reduces remaining volume" do
+    @batch.decrement_remaining!(2.0, "gal")
+    assert_in_delta 8.0, @batch.remaining_volume, 0.001
+  end
+
+  test "decrement_remaining clamps at zero" do
+    @batch.decrement_remaining!(15.0, "gal")
+    assert_equal 0.0, @batch.remaining_volume
+  end
+
+  test "increment_remaining adds to remaining volume" do
+    @batch.update!(remaining_volume: 5.0)
+    @batch.increment_remaining!(2.0, "gal")
+    assert_in_delta 7.0, @batch.remaining_volume, 0.001
+  end
+
+  test "increment_remaining clamps at batch volume" do
+    @batch.update!(remaining_volume: 9.5)
+    @batch.increment_remaining!(5.0, "gal")
+    assert_in_delta 10.0, @batch.remaining_volume, 0.001
+  end
+
+  test "decrement_remaining handles unit conversion (qt to gal)" do
+    @batch.decrement_remaining!(4.0, "qt")
+    # 4 qt = 1 gal
+    assert_in_delta 9.0, @batch.remaining_volume, 0.01
+  end
+
+  test "remaining_percent is correct" do
+    @batch.update!(remaining_volume: 5.0)
+    assert_in_delta 50.0, @batch.remaining_percent, 0.01
+  end
+
+  test "remaining_percent is nil without remaining_volume" do
+    @batch.update!(remaining_volume: nil)
+    assert_nil @batch.remaining_percent
+  end
+
+  test "usage_per_day is zero with no waterings" do
+    assert_in_delta 0.0, @batch.usage_per_day, 0.001
+  end
+
+  test "projected_runout is nil with no usage" do
+    assert_nil @batch.projected_runout
+  end
+
+  test "projected_runout with usage" do
+    plant = Plant.create!(name: "Pothos", project: @project, uid: 999)
+    Watering.create!(plant: plant, recipe_batch: @batch, watered_at: Time.current, volume: 1.0, units: "gal")
+    @batch.update!(remaining_volume: 5.0)
+
+    # 1 gal used in 30 days = 1/30 gal/day
+    # 5 gal remaining / (1/30 gal/day) = 150 days
+    runout = @batch.projected_runout
+    assert runout.present?
+    assert runout > Date.current
+  end
+
+  test "replenishment_urgency is no_usage with no waterings" do
+    assert_equal :no_usage, @batch.replenishment_urgency
+  end
+end

--- a/test/services/recipe_calculator_test.rb
+++ b/test/services/recipe_calculator_test.rb
@@ -1,0 +1,94 @@
+require "test_helper"
+
+class RecipeCalculatorTest < ActiveSupport::TestCase
+  setup do
+    @project = Project.create!(name: "Calculator Test", owner: users(:one))
+    @recipe = Recipe.create!(name: "Test Recipe", project: @project)
+    @source = RecipeSource.create!(name: "FloraMicro", project: @project)
+    @ingredient = RecipeIngredient.create!(
+      recipe: @recipe,
+      recipe_source: @source,
+      amount: 5.0,
+      units: "mL",
+      position: 1
+    )
+  end
+
+  test "scales by volume ratio (same units)" do
+    calc = RecipeCalculator.new(@recipe, target_volume: 2.0, target_units: "gal",
+                                          reference_volume: 1.0, reference_units: "gal")
+    results = calc.calculate
+    assert_equal 1, results.size
+    assert_in_delta 10.0, results.first.amount, 0.001
+    assert_equal "mL", results.first.units
+    assert_equal "FloraMicro", results.first.source_name
+  end
+
+  test "scales by volume ratio (unit conversion)" do
+    calc = RecipeCalculator.new(@recipe, target_volume: 4.0, target_units: "qt",
+                                          reference_volume: 1.0, reference_units: "gal")
+    results = calc.calculate
+    # 4 qt = 1 gal, so scale = 1.0
+    assert_in_delta 5.0, results.first.amount, 0.01
+  end
+
+  test "scales by concentration ratio" do
+    calc = RecipeCalculator.new(@recipe, target_volume: 1.0, target_units: "gal",
+                                          reference_volume: 1.0, reference_units: "gal",
+                                          target_concentration: 800,
+                                          reference_concentration: 400)
+    results = calc.calculate
+    assert_in_delta 10.0, results.first.amount, 0.001
+  end
+
+  test "scales by combined volume and concentration" do
+    calc = RecipeCalculator.new(@recipe, target_volume: 5.0, target_units: "gal",
+                                          reference_volume: 1.0, reference_units: "gal",
+                                          target_concentration: 800,
+                                          reference_concentration: 400)
+    results = calc.calculate
+    # 5x volume * 2x concentration = 10x
+    assert_in_delta 50.0, results.first.amount, 0.001
+  end
+
+  test "returns empty array for recipe with no ingredients" do
+    empty_recipe = Recipe.create!(name: "Empty", project: @project)
+    calc = RecipeCalculator.new(empty_recipe, target_volume: 1.0, target_units: "gal")
+    assert_equal [], calc.calculate
+  end
+
+  test "ignores concentration scaling when reference concentration is zero" do
+    calc = RecipeCalculator.new(@recipe, target_volume: 1.0, target_units: "gal",
+                                          reference_volume: 1.0, reference_units: "gal",
+                                          target_concentration: 800,
+                                          reference_concentration: 0)
+    results = calc.calculate
+    assert_in_delta 5.0, results.first.amount, 0.001
+  end
+
+  test "ignores concentration scaling when only one concentration provided" do
+    calc = RecipeCalculator.new(@recipe, target_volume: 1.0, target_units: "gal",
+                                          reference_volume: 1.0, reference_units: "gal",
+                                          target_concentration: 800)
+    results = calc.calculate
+    assert_in_delta 5.0, results.first.amount, 0.001
+  end
+
+  test "liters to gallons conversion" do
+    calc = RecipeCalculator.new(@recipe, target_volume: 3785.41, target_units: "mL",
+                                          reference_volume: 1.0, reference_units: "gal")
+    results = calc.calculate
+    # 3785.41 mL ≈ 1 gal
+    assert_in_delta 5.0, results.first.amount, 0.05
+  end
+
+  test "supported_units returns expected unit list" do
+    units = RecipeCalculator.supported_units
+    assert_includes units, "mL"
+    assert_includes units, "L"
+    assert_includes units, "gal"
+    assert_includes units, "cups"
+    assert_includes units, "oz"
+    assert_includes units, "qt"
+  end
+end

--- a/test/services/smart_suggestions_test.rb
+++ b/test/services/smart_suggestions_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class SmartSuggestionsTest < ActiveSupport::TestCase
+  setup do
+    @project = Project.create!(name: "SS Test", owner: users(:one))
+    @recipe_a = Recipe.create!(name: "Recipe A", project: @project)
+    @recipe_b = Recipe.create!(name: "Recipe B", project: @project)
+    @recipe_c = Recipe.create!(name: "Recipe C", project: @project)
+  end
+
+  test "top returns at most limit items" do
+    scorer = ->(_item) { rand }
+    svc = SmartSuggestions.new([@recipe_a, @recipe_b, @recipe_c], scorer: scorer, limit: 2)
+    assert_equal 2, svc.top.size
+  end
+
+  test "top returns highest-scoring items first" do
+    scores = { @recipe_a.id => 10, @recipe_b.id => 5, @recipe_c.id => 8 }
+    scorer = ->(item) { scores[item.id] }
+    svc = SmartSuggestions.new([@recipe_a, @recipe_b, @recipe_c], scorer: scorer, limit: 2)
+    top_ids = svc.top.map(&:id)
+    assert_equal [@recipe_a.id, @recipe_c.id], top_ids
+  end
+
+  test "rest excludes top items" do
+    scores = { @recipe_a.id => 10, @recipe_b.id => 5, @recipe_c.id => 8 }
+    scorer = ->(item) { scores[item.id] }
+    svc = SmartSuggestions.new([@recipe_a, @recipe_b, @recipe_c], scorer: scorer, limit: 2)
+    top = svc.top
+    rest = svc.rest(top.map(&:id))
+    assert_equal 1, rest.size
+    assert_equal @recipe_b.id, rest.first.id
+  end
+
+  test "recipe_scorer boosts recipes used on active plants" do
+    plant = Plant.create!(name: "Test", project: @project, uid: 500)
+    PlantRecipe.create!(plant: plant, recipe: @recipe_a, position: 0)
+    plant.update_column(:recipe_id, @recipe_a.id)
+
+    scorer = SmartSuggestions.recipe_scorer(@project)
+    score_a = scorer.call(@recipe_a)
+    score_b = scorer.call(@recipe_b)
+    assert score_a > score_b, "Recipe with plant association should score higher"
+  end
+
+  test "location_scorer returns a callable" do
+    zone = Zone.create!(name: "Zone 1", project: @project)
+    loc = Location.create!(name: "Shelf A", zone: zone, project: @project)
+    scorer = SmartSuggestions.location_scorer(@project)
+    assert_respond_to scorer, :call
+    assert_kind_of Numeric, scorer.call(loc)
+  end
+
+  test "watering_recipe_scorer boosts plant's own recipes" do
+    plant = Plant.create!(name: "Spider", project: @project, uid: 501)
+    PlantRecipe.create!(plant: plant, recipe: @recipe_a, position: 0)
+
+    scorer = SmartSuggestions.watering_recipe_scorer(plant)
+    score_a = scorer.call(@recipe_a)
+    score_b = scorer.call(@recipe_b)
+    assert score_a > score_b, "Plant's own recipe should score higher"
+  end
+end


### PR DESCRIPTION
## Summary
- #91: Smart Suggestions — reusable module for Location, Recipe, Batch selects
- #92: Allow plants to have multiple recipes (or no recipe)
- #93: Allow watering with only Recipe or Source (no Batch required)
- #94: Fertilizer batch tracking — remaining volume + replenishment priority
- #95: Recipe calculator with unit conversion and concentration scaling

## Changes
- New `PlantRecipe` join model, `RecipeCalculator` service, `SmartSuggestions` service
- New Stimulus controllers: `recipe_calculator_controller`, `smart_select_controller`
- Recipe calculator view at `/recipes/calculate`
- RecipeBatch show page with remaining volume tracking
- Watering form updated to support optional batch

## Test plan
- [ ] Model tests for RecipeBatch (remaining volume)
- [ ] Service tests for RecipeCalculator and SmartSuggestions
- [ ] Verify multi-recipe plant form
- [ ] Run `bin/rails test`